### PR TITLE
Add data-driven browser RPG experience

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,10 @@
+title: Browser RPG
+description: >-
+  A simple GitHub Pages site for the BrowserRPG project.
+theme: minima
+
+# Exclude development artifacts from the built site
+exclude:
+  - README.md
+  - Gemfile
+  - Gemfile.lock

--- a/game/data/classes.json
+++ b/game/data/classes.json
@@ -1,0 +1,146 @@
+[
+  {
+    "id": "warden",
+    "name": "Ember Warden",
+    "role": "Vanguard",
+    "description": "Shield-bearing defenders who hold the line with unwavering resolve.",
+    "stats": {
+      "health": 140,
+      "mana": 40,
+      "strength": 12,
+      "agility": 6,
+      "intellect": 6,
+      "armor": 10
+    },
+    "statGrowth": {
+      "health": 22,
+      "mana": 6,
+      "strength": 3,
+      "agility": 1,
+      "intellect": 1,
+      "armor": 2
+    },
+    "abilities": [
+      "Shield Slam",
+      "Guardian's Roar",
+      "Bulwark"
+    ],
+    "startingItems": [
+      "rusty_sword",
+      "training_shield",
+      "healing_potion"
+    ],
+    "startingArmor": "leather_vest",
+    "startingGold": 18,
+    "startingProfessions": ["mining", "blacksmithing"],
+    "startingQuests": ["emberguard_watch"]
+  },
+  {
+    "id": "ranger",
+    "name": "Wild Ranger",
+    "role": "Skirmisher",
+    "description": "Hunters who strike from afar and disappear into the wilds.",
+    "stats": {
+      "health": 120,
+      "mana": 60,
+      "strength": 8,
+      "agility": 12,
+      "intellect": 7,
+      "armor": 6
+    },
+    "statGrowth": {
+      "health": 18,
+      "mana": 10,
+      "strength": 2,
+      "agility": 3,
+      "intellect": 2,
+      "armor": 1
+    },
+    "abilities": [
+      "Twin Arrows",
+      "Camouflaged Step",
+      "Bestial Bond"
+    ],
+    "startingItems": [
+      "scout_bow",
+      "healing_potion",
+      "mana_potion"
+    ],
+    "startingArmor": "leather_vest",
+    "startingGold": 22,
+    "startingProfessions": ["herbalism", "alchemy"],
+    "startingQuests": ["emberguard_watch"]
+  },
+  {
+    "id": "arcanist",
+    "name": "Storm Arcanist",
+    "role": "Spellcaster",
+    "description": "Scholars of the arcane who weave the storm into devastating spells.",
+    "stats": {
+      "health": 100,
+      "mana": 120,
+      "strength": 5,
+      "agility": 7,
+      "intellect": 14,
+      "armor": 4
+    },
+    "statGrowth": {
+      "health": 14,
+      "mana": 18,
+      "strength": 1,
+      "agility": 2,
+      "intellect": 4,
+      "armor": 1
+    },
+    "abilities": [
+      "Lightning Coil",
+      "Arcane Surge",
+      "Tempest Barrier"
+    ],
+    "startingItems": [
+      "menders_tome",
+      "focus_crystal",
+      "mana_potion"
+    ],
+    "startingArmor": "acolyte_robes",
+    "startingGold": 20,
+    "startingProfessions": ["enchanting", "tailoring"],
+    "startingQuests": ["emberguard_watch", "arcanists_request"]
+  },
+  {
+    "id": "templar",
+    "name": "Radiant Templar",
+    "role": "Battle Cleric",
+    "description": "Warrior-priests who fight with steel in hand and light in their hearts.",
+    "stats": {
+      "health": 130,
+      "mana": 90,
+      "strength": 9,
+      "agility": 7,
+      "intellect": 10,
+      "armor": 8
+    },
+    "statGrowth": {
+      "health": 20,
+      "mana": 12,
+      "strength": 2,
+      "agility": 1,
+      "intellect": 3,
+      "armor": 2
+    },
+    "abilities": [
+      "Sunlance",
+      "Radiant Ward",
+      "Revitalizing Hymn"
+    ],
+    "startingItems": [
+      "rusty_sword",
+      "menders_tome",
+      "healing_potion"
+    ],
+    "startingArmor": "acolyte_robes",
+    "startingGold": 21,
+    "startingProfessions": ["herbalism", "enchanting"],
+    "startingQuests": ["emberguard_watch"]
+  }
+]

--- a/game/data/dungeons.json
+++ b/game/data/dungeons.json
@@ -1,0 +1,68 @@
+[
+  {
+    "id": "ember_halls",
+    "name": "Ember Halls",
+    "zoneId": "emberglade_watch",
+    "description": "A labyrinth of charred roots harboring the ancient spirit that fuels the wildfires.",
+    "levelRange": [4, 8],
+    "encounterIds": ["ember_whelp", "ember_sprite", "emberkin_guard"],
+    "bossId": "ember_spirit",
+    "objectives": [
+      "Extinguish the Cinder Altars",
+      "Defeat the Ancient Ember Spirit"
+    ],
+    "rewards": {
+      "xp": 220,
+      "gold": 30,
+      "items": ["ember_coal", "warden_insignia"]
+    },
+    "environmentalEffects": [
+      "Lingering heat increases fire damage dealt and taken.",
+      "Falling embers may ignite the battlefield."
+    ]
+  },
+  {
+    "id": "frostspire_depths",
+    "name": "Frostspire Depths",
+    "zoneId": "shiverpeak_expanse",
+    "description": "Frozen caverns carved beneath the storm-ravaged peaks.",
+    "levelRange": [7, 11],
+    "encounterIds": ["frost_troll", "glacial_wisp"],
+    "bossId": "frostwarden",
+    "objectives": [
+      "Free the trapped storm sages",
+      "Shatter the Frostwarden's heartstone"
+    ],
+    "rewards": {
+      "xp": 320,
+      "gold": 46,
+      "items": ["storm_essence", "rejuvenation_potion"]
+    },
+    "environmentalEffects": [
+      "Howling winds sap agility unless you huddle near braziers.",
+      "Frozen ground may stun careless adventurers."
+    ]
+  },
+  {
+    "id": "umbral_catacombs",
+    "name": "Umbral Catacombs",
+    "zoneId": "umbral_hollow",
+    "description": "Collapsed temples now riddled with void rifts and restless spirits.",
+    "levelRange": [9, 13],
+    "encounterIds": ["umbral_stalker", "voidcaller"],
+    "bossId": "void_revenant",
+    "objectives": [
+      "Seal the rift anchors",
+      "Banish the Void Revenant"
+    ],
+    "rewards": {
+      "xp": 420,
+      "gold": 58,
+      "items": ["shadow_daggers", "storm_essence"]
+    },
+    "environmentalEffects": [
+      "Shifting shadows hide traps until revealed by light.",
+      "Periodic void pulses drain mana." 
+    ]
+  }
+]

--- a/game/data/enemies.json
+++ b/game/data/enemies.json
@@ -1,0 +1,161 @@
+[
+  {
+    "id": "ember_whelp",
+    "name": "Ember Whelp",
+    "level": 3,
+    "type": "dragonkin",
+    "zoneIds": ["emberglade_watch"],
+    "dungeonIds": ["ember_halls"],
+    "stats": { "health": 70, "power": 14, "defense": 4, "crit": 6 },
+    "abilities": ["Cinder Breath", "Tail Swipe"],
+    "xp": 45,
+    "gold": 5,
+    "loot": [
+      { "itemId": "ember_scale", "chance": 0.55 },
+      { "itemId": "ember_leaf", "chance": 0.3 }
+    ]
+  },
+  {
+    "id": "ember_sprite",
+    "name": "Ember Sprite",
+    "level": 2,
+    "type": "elemental",
+    "zoneIds": ["emberglade_watch"],
+    "dungeonIds": ["ember_halls"],
+    "stats": { "health": 55, "power": 12, "defense": 3, "crit": 10 },
+    "abilities": ["Scorch", "Wildfire Surge"],
+    "xp": 35,
+    "gold": 4,
+    "loot": [
+      { "itemId": "ember_coal", "chance": 0.25 },
+      { "itemId": "ember_leaf", "chance": 0.4 }
+    ]
+  },
+  {
+    "id": "emberkin_guard",
+    "name": "Emberkin Guard",
+    "level": 5,
+    "type": "humanoid",
+    "zoneIds": ["emberglade_watch"],
+    "dungeonIds": ["ember_halls"],
+    "stats": { "health": 110, "power": 18, "defense": 8, "crit": 8 },
+    "abilities": ["Shield Bash", "Fan of Flames"],
+    "xp": 70,
+    "gold": 8,
+    "loot": [
+      { "itemId": "bronze_ore", "chance": 0.35 },
+      { "itemId": "healing_potion", "chance": 0.2 }
+    ]
+  },
+  {
+    "id": "ember_spirit",
+    "name": "Ancient Ember Spirit",
+    "level": 7,
+    "type": "elemental",
+    "zoneIds": ["emberglade_watch"],
+    "dungeonIds": ["ember_halls"],
+    "stats": { "health": 220, "power": 28, "defense": 10, "crit": 12 },
+    "abilities": ["Flame Nova", "Blazing Shell", "Heatwave"],
+    "xp": 160,
+    "gold": 22,
+    "loot": [
+      { "itemId": "ember_coal", "chance": 0.8, "quantity": 2 },
+      { "itemId": "warden_insignia", "chance": 0.25 }
+    ]
+  },
+  {
+    "id": "frost_troll",
+    "name": "Frost Troll",
+    "level": 8,
+    "type": "giant",
+    "zoneIds": ["shiverpeak_expanse"],
+    "dungeonIds": ["frostspire_depths"],
+    "stats": { "health": 260, "power": 26, "defense": 14, "crit": 4 },
+    "abilities": ["Ice Maul", "Frozen Hide"],
+    "xp": 190,
+    "gold": 24,
+    "loot": [
+      { "itemId": "spring_water", "chance": 0.4 },
+      { "itemId": "glimmer_silk", "chance": 0.2 }
+    ]
+  },
+  {
+    "id": "glacial_wisp",
+    "name": "Glacial Wisp",
+    "level": 7,
+    "type": "elemental",
+    "zoneIds": ["shiverpeak_expanse"],
+    "dungeonIds": ["frostspire_depths"],
+    "stats": { "health": 150, "power": 24, "defense": 8, "crit": 14 },
+    "abilities": ["Frostbolt", "Icy Veil"],
+    "xp": 150,
+    "gold": 18,
+    "loot": [
+      { "itemId": "storm_essence", "chance": 0.35 }
+    ]
+  },
+  {
+    "id": "frostwarden",
+    "name": "Frostwarden Matriarch",
+    "level": 10,
+    "type": "giant",
+    "zoneIds": ["shiverpeak_expanse"],
+    "dungeonIds": ["frostspire_depths"],
+    "stats": { "health": 320, "power": 32, "defense": 16, "crit": 6 },
+    "abilities": ["Blizzard Crash", "Glacial Spines", "Frozen Heart"],
+    "xp": 260,
+    "gold": 35,
+    "loot": [
+      { "itemId": "storm_essence", "chance": 0.6 },
+      { "itemId": "rejuvenation_potion", "chance": 0.4 }
+    ]
+  },
+  {
+    "id": "umbral_stalker",
+    "name": "Umbral Stalker",
+    "level": 9,
+    "type": "beast",
+    "zoneIds": ["umbral_hollow"],
+    "dungeonIds": ["umbral_catacombs"],
+    "stats": { "health": 210, "power": 30, "defense": 9, "crit": 18 },
+    "abilities": ["Shadow Pounce", "Night Veil"],
+    "xp": 210,
+    "gold": 28,
+    "loot": [
+      { "itemId": "luminous_thread", "chance": 0.5 },
+      { "itemId": "shadow_daggers", "chance": 0.15 }
+    ]
+  },
+  {
+    "id": "voidcaller",
+    "name": "Voidcaller Adept",
+    "level": 11,
+    "type": "humanoid",
+    "zoneIds": ["umbral_hollow"],
+    "dungeonIds": ["umbral_catacombs"],
+    "stats": { "health": 240, "power": 34, "defense": 12, "crit": 16 },
+    "abilities": ["Void Lance", "Abyssal Barrier"],
+    "xp": 240,
+    "gold": 30,
+    "loot": [
+      { "itemId": "storm_essence", "chance": 0.3 },
+      { "itemId": "glimmer_silk", "chance": 0.3 }
+    ]
+  },
+  {
+    "id": "void_revenant",
+    "name": "Void Revenant",
+    "level": 12,
+    "type": "undead",
+    "zoneIds": ["umbral_hollow"],
+    "dungeonIds": ["umbral_catacombs"],
+    "stats": { "health": 360, "power": 36, "defense": 15, "crit": 12 },
+    "abilities": ["Rift Rend", "Soul Rupture", "Gravity Well"],
+    "xp": 320,
+    "gold": 44,
+    "loot": [
+      { "itemId": "shadow_daggers", "chance": 0.25 },
+      { "itemId": "warden_insignia", "chance": 0.1 }
+    ]
+  }
+]

--- a/game/data/items.json
+++ b/game/data/items.json
@@ -1,0 +1,214 @@
+[
+  {
+    "id": "rusty_sword",
+    "name": "Rusty Sword",
+    "type": "weapon",
+    "rarity": "common",
+    "description": "An old blade with enough bite to get a recruit started.",
+    "stats": { "attack": 4 },
+    "value": 3,
+    "tags": ["starter"]
+  },
+  {
+    "id": "training_shield",
+    "name": "Training Shield",
+    "type": "off-hand",
+    "rarity": "common",
+    "description": "A dented shield that still knows how to deflect a blow.",
+    "stats": { "armor": 6 },
+    "value": 4,
+    "tags": ["starter"]
+  },
+  {
+    "id": "scout_bow",
+    "name": "Scout's Bow",
+    "type": "weapon",
+    "rarity": "common",
+    "description": "A light bow favored by rangers on patrol.",
+    "stats": { "attack": 5 },
+    "value": 5,
+    "tags": ["starter"]
+  },
+  {
+    "id": "initiate_daggers",
+    "name": "Initiate's Daggers",
+    "type": "weapon",
+    "rarity": "common",
+    "description": "Balanced blades for those who prefer shadows to sunlight.",
+    "stats": { "attack": 5 },
+    "value": 5,
+    "tags": ["starter"]
+  },
+  {
+    "id": "menders_tome",
+    "name": "Mender's Tome",
+    "type": "weapon",
+    "rarity": "common",
+    "description": "A worn tome filled with luminous prayers.",
+    "stats": { "spellPower": 5 },
+    "value": 6,
+    "tags": ["starter"]
+  },
+  {
+    "id": "focus_crystal",
+    "name": "Focus Crystal",
+    "type": "off-hand",
+    "rarity": "common",
+    "description": "A crystal that amplifies arcane focus when held.",
+    "stats": { "spellPower": 3 },
+    "value": 4
+  },
+  {
+    "id": "leather_vest",
+    "name": "Leather Vest",
+    "type": "armor",
+    "rarity": "common",
+    "description": "Toughened hide that offers nimble protection.",
+    "stats": { "armor": 5 },
+    "value": 4
+  },
+  {
+    "id": "acolyte_robes",
+    "name": "Acolyte Robes",
+    "type": "armor",
+    "rarity": "common",
+    "description": "Threadbare robes woven with faint enchantments.",
+    "stats": { "armor": 3, "mana": 10 },
+    "value": 4
+  },
+  {
+    "id": "healing_potion",
+    "name": "Healing Draught",
+    "type": "consumable",
+    "rarity": "common",
+    "description": "Restores a portion of vitality when quaffed.",
+    "effect": { "health": 40 },
+    "value": 6
+  },
+  {
+    "id": "mana_potion",
+    "name": "Sapphire Phial",
+    "type": "consumable",
+    "rarity": "common",
+    "description": "A glittering potion that refills arcane reserves.",
+    "effect": { "mana": 35 },
+    "value": 6
+  },
+  {
+    "id": "ember_leaf",
+    "name": "Emberleaf",
+    "type": "material",
+    "rarity": "common",
+    "description": "A fiery herb that grows only in the emberlit glades.",
+    "value": 2,
+    "tags": ["herbalism"]
+  },
+  {
+    "id": "bronze_ore",
+    "name": "Bronze Ore",
+    "type": "material",
+    "rarity": "common",
+    "description": "Chunks of ore streaked with metallic shimmer.",
+    "value": 2,
+    "tags": ["mining"]
+  },
+  {
+    "id": "ember_coal",
+    "name": "Ember Coal",
+    "type": "material",
+    "rarity": "uncommon",
+    "description": "A smoldering chunk harvested from ember spirits.",
+    "value": 5,
+    "tags": ["mining"]
+  },
+  {
+    "id": "spring_water",
+    "name": "Springwater Flask",
+    "type": "material",
+    "rarity": "common",
+    "description": "Crystal-clear water bottled from distant peaks.",
+    "value": 1,
+    "tags": ["alchemy"]
+  },
+  {
+    "id": "ember_scale",
+    "name": "Ember Scale",
+    "type": "material",
+    "rarity": "uncommon",
+    "description": "A scale that shimmers with residual heat.",
+    "value": 7,
+    "tags": ["loot"]
+  },
+  {
+    "id": "glimmer_silk",
+    "name": "Glimmer Silk",
+    "type": "material",
+    "rarity": "uncommon",
+    "description": "Silk that refracts the faintest light in prismatic hues.",
+    "value": 6,
+    "tags": ["tailoring"]
+  },
+  {
+    "id": "storm_essence",
+    "name": "Storm Essence",
+    "type": "material",
+    "rarity": "rare",
+    "description": "A vial of lightning captured from tempest elementals.",
+    "value": 12,
+    "tags": ["enchanting"]
+  },
+  {
+    "id": "luminous_thread",
+    "name": "Luminous Thread",
+    "type": "material",
+    "rarity": "uncommon",
+    "description": "Thread spun from the cocoons of glowmoths.",
+    "value": 5,
+    "tags": ["tailoring"]
+  },
+  {
+    "id": "bronze_sword",
+    "name": "Bronze Longsword",
+    "type": "weapon",
+    "rarity": "uncommon",
+    "description": "A newly forged blade balanced for seasoned fighters.",
+    "stats": { "attack": 9 },
+    "value": 12
+  },
+  {
+    "id": "ember_staff",
+    "name": "Emberweave Staff",
+    "type": "weapon",
+    "rarity": "uncommon",
+    "description": "Wood wrapped in emberweave that channels raw flame.",
+    "stats": { "spellPower": 10 },
+    "value": 14
+  },
+  {
+    "id": "shadow_daggers",
+    "name": "Shadow Daggers",
+    "type": "weapon",
+    "rarity": "uncommon",
+    "description": "Daggers quenched in the void, eager for backstabs.",
+    "stats": { "attack": 10 },
+    "value": 15
+  },
+  {
+    "id": "rejuvenation_potion",
+    "name": "Rejuvenation Potion",
+    "type": "consumable",
+    "rarity": "uncommon",
+    "description": "A tonic that revitalizes both body and spirit.",
+    "effect": { "health": 40, "mana": 25 },
+    "value": 12
+  },
+  {
+    "id": "warden_insignia",
+    "name": "Warden's Insignia",
+    "type": "trinket",
+    "rarity": "rare",
+    "description": "A badge of honor granted for defending Emberglade Watch.",
+    "stats": { "armor": 4, "attack": 4 },
+    "value": 25
+  }
+]

--- a/game/data/npcs.json
+++ b/game/data/npcs.json
@@ -1,0 +1,113 @@
+[
+  {
+    "id": "sentinel_lyra",
+    "name": "Sentinel Lyra",
+    "title": "Watch Captain",
+    "role": "quest_giver",
+    "zoneId": "emberglade_watch",
+    "faction": "Emberguard",
+    "dialogue": [
+      "Hold the line and the wildfires will break before us.",
+      "Report any unusual flames. The spirit grows restless.",
+      "The Emberguard needs heroes willing to step beyond the wall."
+    ],
+    "questIds": ["emberguard_watch"],
+    "services": ["quests"]
+  },
+  {
+    "id": "brock_ironbeard",
+    "name": "Brock Ironbeard",
+    "title": "Quartermaster",
+    "role": "merchant",
+    "zoneId": "emberglade_watch",
+    "faction": "Emberguard",
+    "dialogue": [
+      "Got gear that survived the last blaze. Take a look.",
+      "Ore coming in slow this week. Pay's better for those who bring it.",
+      "Mind the ash on the hilts. It bites back."
+    ],
+    "inventory": [
+      { "itemId": "healing_potion", "price": 8 },
+      { "itemId": "mana_potion", "price": 8 },
+      { "itemId": "bronze_sword", "price": 28 }
+    ],
+    "buyTypes": ["material", "loot"],
+    "services": ["trading", "repairs"]
+  },
+  {
+    "id": "sage_elowen",
+    "name": "Sage Elowen",
+    "title": "Grove Archivist",
+    "role": "lorekeeper",
+    "zoneId": "emberglade_watch",
+    "dialogue": [
+      "The glade remembers every ember ever lit.",
+      "I can teach you the names of the spirits, if you listen."
+    ],
+    "services": ["lore", "profession_trainer"],
+    "trainsProfessions": ["herbalism", "alchemy"]
+  },
+  {
+    "id": "stormcaller_ivra",
+    "name": "Stormcaller Ivra",
+    "title": "Tempest Sage",
+    "role": "quest_giver",
+    "zoneId": "shiverpeak_expanse",
+    "dialogue": [
+      "The storm speaks. Few understand its warnings.",
+      "Bring warmth for the sages trapped beneath the ice."
+    ],
+    "questIds": ["arcanists_request"],
+    "services": ["quests", "profession_trainer"],
+    "trainsProfessions": ["enchanting"]
+  },
+  {
+    "id": "quartermaster_hagan",
+    "name": "Quartermaster Hagan",
+    "title": "Stormwatch Supply",
+    "role": "merchant",
+    "zoneId": "shiverpeak_expanse",
+    "dialogue": [
+      "Metal's brittle up here. Bring ore that's worthy.",
+      "Trade frost-bitten trophies for warm gear."
+    ],
+    "inventory": [
+      { "itemId": "rejuvenation_potion", "price": 18 },
+      { "itemId": "glimmer_silk", "price": 12 },
+      { "itemId": "storm_essence", "price": 26 }
+    ],
+    "buyTypes": ["material", "consumable"],
+    "services": ["trading"]
+  },
+  {
+    "id": "shade_broker",
+    "name": "Shade Broker",
+    "title": "Shadowmarket Dealer",
+    "role": "merchant",
+    "zoneId": "umbral_hollow",
+    "dialogue": [
+      "Secrets for sale. Coin preferred, favors accepted.",
+      "Void relics hum louder the deeper you go."
+    ],
+    "inventory": [
+      { "itemId": "shadow_daggers", "price": 36 },
+      { "itemId": "luminous_thread", "price": 14 },
+      { "itemId": "storm_essence", "price": 30 }
+    ],
+    "buyTypes": ["loot", "trinket"],
+    "services": ["trading", "information"]
+  },
+  {
+    "id": "archivist_mira",
+    "name": "Archivist Mira",
+    "title": "Void Scholar",
+    "role": "quest_giver",
+    "zoneId": "umbral_hollow",
+    "dialogue": [
+      "The catacombs shift nightly. Only the brave map them.",
+      "Bring back records of the void pulses, and I'll reward you handsomely."
+    ],
+    "questIds": ["void_research"],
+    "services": ["quests", "lore"]
+  }
+]

--- a/game/data/professions.json
+++ b/game/data/professions.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "mining",
+    "name": "Mining",
+    "type": "gathering",
+    "description": "Harvest ore and mineral fuels from the zones' rich veins.",
+    "gatherables": ["bronze_ore", "ember_coal"],
+    "tools": "Pickaxe"
+  },
+  {
+    "id": "blacksmithing",
+    "name": "Blacksmithing",
+    "type": "crafting",
+    "description": "Forge weapons and shields for the Emberguard.",
+    "requires": ["mining"],
+    "crafts": [
+      {
+        "itemId": "bronze_sword",
+        "requirements": { "bronze_ore": 3, "ember_coal": 1 },
+        "description": "Hammer bronze ore into a serviceable longsword."
+      }
+    ]
+  },
+  {
+    "id": "herbalism",
+    "name": "Herbalism",
+    "type": "gathering",
+    "description": "Collect rare herbs and spores from the wilds.",
+    "gatherables": ["ember_leaf"],
+    "tools": "Foraging Satchel"
+  },
+  {
+    "id": "alchemy",
+    "name": "Alchemy",
+    "type": "crafting",
+    "description": "Brew tonics and elixirs that restore and empower adventurers.",
+    "requires": ["herbalism"],
+    "crafts": [
+      {
+        "itemId": "rejuvenation_potion",
+        "requirements": { "ember_leaf": 2, "spring_water": 1 },
+        "description": "Infuse emberleaf into pristine springwater for a revitalizing draught."
+      }
+    ]
+  },
+  {
+    "id": "enchanting",
+    "name": "Enchanting",
+    "type": "crafting",
+    "description": "Imbue weapons and armor with elemental energies.",
+    "requires": [],
+    "crafts": [
+      {
+        "itemId": "ember_staff",
+        "requirements": { "storm_essence": 1, "ember_leaf": 1 },
+        "description": "Bind storm essence to a staff using emberleaf as a catalyst."
+      }
+    ]
+  },
+  {
+    "id": "tailoring",
+    "name": "Tailoring",
+    "type": "crafting",
+    "description": "Sew light armor and trinkets using woven fibers.",
+    "requires": [],
+    "crafts": [
+      {
+        "itemId": "focus_crystal",
+        "requirements": { "glimmer_silk": 1, "luminous_thread": 2 },
+        "description": "Wrap glimmer silk around luminous thread to cradle a focus crystal."
+      }
+    ]
+  }
+]

--- a/game/data/quests.json
+++ b/game/data/quests.json
@@ -1,0 +1,93 @@
+[
+  {
+    "id": "emberguard_watch",
+    "name": "Stoke the Watchfires",
+    "giverId": "sentinel_lyra",
+    "summary": "Assist the Emberguard in defending the glade from roaming threats.",
+    "description": "Sentinel Lyra has asked you to cull the emberspawn near the wall and report back with news of the threat.",
+    "objectives": [
+      {
+        "id": "cull_whelps",
+        "description": "Defeat Ember Whelps near the Ember Beacon.",
+        "type": "kill",
+        "target": "ember_whelp",
+        "count": 3
+      },
+      {
+        "id": "report_lyra",
+        "description": "Report back to Sentinel Lyra.",
+        "type": "talk",
+        "target": "sentinel_lyra",
+        "count": 1
+      }
+    ],
+    "rewards": {
+      "xp": 150,
+      "gold": 12,
+      "items": ["healing_potion"]
+    }
+  },
+  {
+    "id": "arcanists_request",
+    "name": "Arcane Residue",
+    "giverId": "stormcaller_ivra",
+    "summary": "Collect storm-touched reagents for Stormcaller Ivra's research.",
+    "description": "Ivra seeks components that still hum with latent magic. Gather them from across the Shiverpeak Expanse.",
+    "objectives": [
+      {
+        "id": "gather_essence",
+        "description": "Collect Storm Essence from glacial wisps.",
+        "type": "collect",
+        "target": "storm_essence",
+        "count": 2
+      },
+      {
+        "id": "deliver_ivra",
+        "description": "Deliver the reagents to Stormcaller Ivra.",
+        "type": "talk",
+        "target": "stormcaller_ivra",
+        "count": 1
+      }
+    ],
+    "rewards": {
+      "xp": 260,
+      "gold": 28,
+      "items": ["ember_staff"]
+    }
+  },
+  {
+    "id": "void_research",
+    "name": "Echoes of the Void",
+    "giverId": "archivist_mira",
+    "summary": "Map the shifting catacombs and banish the revenant leading the incursions.",
+    "description": "Archivist Mira needs detailed notes from within the Umbral Catacombs to stem the void's advance.",
+    "objectives": [
+      {
+        "id": "chart_catacombs",
+        "description": "Explore the Umbral Catacombs for rift anchors.",
+        "type": "dungeon",
+        "target": "umbral_catacombs",
+        "count": 1
+      },
+      {
+        "id": "slay_revenant",
+        "description": "Defeat the Void Revenant.",
+        "type": "kill",
+        "target": "void_revenant",
+        "count": 1
+      },
+      {
+        "id": "report_mira",
+        "description": "Report back to Archivist Mira.",
+        "type": "talk",
+        "target": "archivist_mira",
+        "count": 1
+      }
+    ],
+    "rewards": {
+      "xp": 420,
+      "gold": 62,
+      "items": ["shadow_daggers", "warden_insignia"]
+    }
+  }
+]

--- a/game/data/zones.json
+++ b/game/data/zones.json
@@ -1,0 +1,50 @@
+[
+  {
+    "id": "emberglade_watch",
+    "name": "Emberglade Watch",
+    "description": "A fortified grove where the Emberguard hold back encroaching flame-born threats.",
+    "levelRange": [1, 6],
+    "climate": "Temperate wildfire",
+    "enemyIds": ["ember_whelp", "ember_sprite", "emberkin_guard"],
+    "npcIds": ["sentinel_lyra", "brock_ironbeard", "sage_elowen"],
+    "gatherables": ["ember_leaf", "bronze_ore"],
+    "dungeonIds": ["ember_halls"],
+    "pointsOfInterest": [
+      "The Ember Beacon",
+      "Rootbound Barracks",
+      "The Searing Gate"
+    ]
+  },
+  {
+    "id": "shiverpeak_expanse",
+    "name": "Shiverpeak Expanse",
+    "description": "Icy ridgelines battered by eternal storms where frost giants reign.",
+    "levelRange": [6, 10],
+    "climate": "Arctic",
+    "enemyIds": ["frost_troll", "glacial_wisp", "frostwarden"],
+    "npcIds": ["stormcaller_ivra", "quartermaster_hagan"],
+    "gatherables": ["spring_water", "glimmer_silk"],
+    "dungeonIds": ["frostspire_depths"],
+    "pointsOfInterest": [
+      "The Frozen Orrery",
+      "Shattered Stormspire",
+      "Ivra's Observatory"
+    ]
+  },
+  {
+    "id": "umbral_hollow",
+    "name": "Umbral Hollow",
+    "description": "A twilight forest stitched together by void rifts and whispering shadows.",
+    "levelRange": [9, 13],
+    "climate": "Perpetual dusk",
+    "enemyIds": ["umbral_stalker", "voidcaller", "void_revenant"],
+    "npcIds": ["shade_broker", "archivist_mira"],
+    "gatherables": ["luminous_thread", "storm_essence"],
+    "dungeonIds": ["umbral_catacombs"],
+    "pointsOfInterest": [
+      "The Whispering Cairn",
+      "Shadowmarket Crossing",
+      "The Broken Sigil"
+    ]
+  }
+]

--- a/game/game.css
+++ b/game/game.css
@@ -1,0 +1,598 @@
+:root {
+  --bg: #0f1319;
+  --panel-bg: rgba(24, 32, 44, 0.92);
+  --panel-border: rgba(93, 133, 208, 0.4);
+  --accent: #ffb347;
+  --accent-strong: #ff7f50;
+  --text: #f1f5ff;
+  --muted: #94a3b8;
+  --success: #4ade80;
+  --danger: #f87171;
+  --info: #60a5fa;
+  --card-bg: rgba(18, 24, 33, 0.85);
+  --shadow: 0 12px 30px rgba(0, 0, 0, 0.35);
+  font-size: 16px;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at 20% 20%, rgba(255, 184, 108, 0.12), transparent 35%),
+              radial-gradient(circle at 80% 0%, rgba(96, 165, 250, 0.12), transparent 40%),
+              linear-gradient(135deg, #0b1018, #141a23 55%, #101521);
+  color: var(--text);
+  font-family: "Segoe UI", "Inter", system-ui, -apple-system, sans-serif;
+  min-height: 100vh;
+}
+
+.loading {
+  position: fixed;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  background: rgba(12, 17, 24, 0.94);
+  color: var(--muted);
+  font-size: 1.25rem;
+  letter-spacing: 0.05em;
+  z-index: 60;
+}
+
+.hidden {
+  display: none !important;
+}
+
+.app {
+  display: flex;
+  min-height: 100vh;
+  width: 100%;
+}
+
+.player-panel {
+  width: 320px;
+  background: var(--panel-bg);
+  border-right: 1px solid var(--panel-border);
+  padding: 1.5rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  position: sticky;
+  top: 0;
+  max-height: 100vh;
+  overflow-y: auto;
+}
+
+.player-header h1 {
+  margin: 0;
+  font-size: 1.75rem;
+  letter-spacing: 0.04em;
+}
+
+.tagline {
+  margin: 0.25rem 0 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.player-summary,
+.player-actions,
+.player-stats,
+.player-abilities,
+.player-professions,
+.player-equipment {
+  background: var(--card-bg);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  border-radius: 12px;
+  padding: 1rem;
+  box-shadow: var(--shadow);
+}
+
+.player-summary {
+  display: grid;
+  gap: 0.6rem;
+}
+
+.summary-field {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.95rem;
+}
+
+.summary-field .label {
+  color: var(--muted);
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+}
+
+.summary-field .value {
+  font-weight: 600;
+}
+
+.resource-row {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  align-items: center;
+  gap: 0.6rem;
+  font-size: 0.9rem;
+}
+
+.resource-bar {
+  height: 8px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.2);
+  overflow: hidden;
+}
+
+.resource-fill {
+  height: 100%;
+  width: 50%;
+  border-radius: 999px;
+  background: linear-gradient(90deg, #ef4444, #f97316);
+  transition: width 0.3s ease;
+}
+
+.resource-fill.mana {
+  background: linear-gradient(90deg, #38bdf8, #818cf8);
+}
+
+.player-actions {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.player-actions button {
+  flex: 1 1 auto;
+}
+
+.player-stats h2,
+.player-abilities h2,
+.player-professions h2,
+.player-equipment h2 {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.player-stats ul,
+.player-abilities ul,
+.player-professions ul,
+.player-equipment ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.player-equipment ul li span {
+  color: var(--muted);
+  margin-right: 0.35rem;
+}
+
+.main-area {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.activity-tabs {
+  display: flex;
+  gap: 0.5rem;
+  padding: 1rem 1.25rem;
+  background: rgba(15, 19, 25, 0.85);
+  border-bottom: 1px solid var(--panel-border);
+  position: sticky;
+  top: 0;
+  z-index: 20;
+  backdrop-filter: blur(8px);
+}
+
+.activity-tabs button {
+  background: rgba(59, 130, 246, 0.12);
+  border: 1px solid rgba(59, 130, 246, 0.3);
+  color: var(--text);
+  padding: 0.65rem 1.25rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+}
+
+.activity-tabs button:hover,
+.activity-tabs button:focus-visible {
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.activity-tabs button.active {
+  background: linear-gradient(135deg, rgba(255, 179, 71, 0.24), rgba(255, 111, 97, 0.2));
+  border-color: rgba(255, 179, 71, 0.6);
+  color: var(--accent);
+}
+
+.screen {
+  display: none;
+  padding: 1.5rem 1.75rem 1.75rem;
+  animation: fadeIn 0.3s ease;
+}
+
+.screen.active {
+  display: block;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.screen-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.screen-column {
+  background: var(--card-bg);
+  border-radius: 16px;
+  padding: 1.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  box-shadow: var(--shadow);
+}
+
+.screen-column h3 {
+  margin-top: 0;
+  margin-bottom: 0.5rem;
+  font-size: 1rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  display: block;
+  margin-bottom: 0.4rem;
+  color: var(--muted);
+}
+
+select,
+input[type="text"] {
+  width: 100%;
+  padding: 0.65rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 19, 25, 0.75);
+  color: var(--text);
+  font-size: 0.95rem;
+  margin-bottom: 1rem;
+}
+
+select:focus,
+input[type="text"]:focus {
+  outline: 2px solid rgba(255, 179, 71, 0.5);
+  outline-offset: 2px;
+}
+
+button {
+  background: linear-gradient(135deg, rgba(255, 179, 71, 0.2), rgba(255, 111, 97, 0.25));
+  border: 1px solid rgba(255, 179, 71, 0.4);
+  color: var(--text);
+  padding: 0.65rem 1.1rem;
+  border-radius: 999px;
+  cursor: pointer;
+  font-size: 0.95rem;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+  font-weight: 600;
+}
+
+button:hover,
+button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: 0 8px 20px rgba(255, 179, 71, 0.25);
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+  transform: none;
+  box-shadow: none;
+}
+
+.button-row {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.description {
+  color: rgba(224, 231, 255, 0.7);
+  line-height: 1.5;
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+.bullet-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.bullet-list li::before {
+  content: "•";
+  margin-right: 0.5rem;
+  color: var(--accent);
+}
+
+.details-card {
+  background: rgba(10, 14, 20, 0.75);
+  border-radius: 14px;
+  padding: 1rem;
+  border: 1px solid rgba(94, 234, 212, 0.16);
+  min-height: 120px;
+  line-height: 1.5;
+  font-size: 0.95rem;
+}
+
+.list-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1rem;
+}
+
+.card {
+  background: rgba(13, 18, 26, 0.85);
+  border-radius: 16px;
+  padding: 1rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  box-shadow: var(--shadow);
+}
+
+.card-header {
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+
+.card-body {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.8);
+  line-height: 1.45;
+}
+
+.card-footer {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.log-panel {
+  margin: 0 1.75rem 2rem;
+  padding: 1.25rem 1.5rem;
+  border-radius: 16px;
+  background: rgba(8, 12, 18, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: var(--shadow);
+}
+
+.log-panel h2 {
+  margin: 0 0 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.log-entries {
+  max-height: 220px;
+  overflow-y: auto;
+  display: grid;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.log-entry {
+  padding: 0.6rem 0.75rem;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  background: rgba(13, 17, 23, 0.7);
+  line-height: 1.4;
+}
+
+.log-entry.info {
+  border-color: rgba(96, 165, 250, 0.3);
+}
+
+.log-entry.success {
+  border-color: rgba(74, 222, 128, 0.3);
+}
+
+.log-entry.warning {
+  border-color: rgba(250, 204, 21, 0.3);
+}
+
+.log-entry.danger {
+  border-color: rgba(248, 113, 113, 0.3);
+}
+
+.modal {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(5, 7, 11, 0.9);
+  z-index: 80;
+}
+
+.modal-content {
+  background: rgba(13, 19, 29, 0.95);
+  border-radius: 18px;
+  padding: 2rem;
+  width: min(480px, 90vw);
+  box-shadow: var(--shadow);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.modal h2 {
+  margin: 0 0 1.25rem;
+  letter-spacing: 0.06em;
+}
+
+.modal-actions {
+  margin-top: 1.25rem;
+  text-align: right;
+}
+
+.overlay-panel {
+  position: fixed;
+  inset: 0;
+  background: rgba(7, 10, 16, 0.85);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 70;
+  padding: 2rem;
+}
+
+.overlay-panel.open {
+  display: flex;
+}
+
+.overlay-content {
+  background: rgba(13, 19, 29, 0.95);
+  border-radius: 18px;
+  padding: 1.75rem;
+  width: min(760px, 95vw);
+  max-height: 85vh;
+  overflow-y: auto;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: var(--shadow);
+}
+
+.overlay-content header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.close-button {
+  background: transparent;
+  border: none;
+  color: var(--muted);
+  font-size: 1.5rem;
+  line-height: 1;
+  padding: 0;
+}
+
+.close-button:hover,
+.close-button:focus-visible {
+  color: var(--accent);
+  transform: none;
+  box-shadow: none;
+}
+
+#questLogContent {
+  display: grid;
+  gap: 1rem;
+}
+
+.quest-card {
+  background: rgba(13, 17, 24, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 16px;
+  padding: 1.25rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.quest-card header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+
+.quest-card h3 {
+  margin: 0;
+  font-size: 1.05rem;
+  letter-spacing: 0.04em;
+}
+
+.quest-card .status {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--muted);
+}
+
+.quest-objectives {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.quest-objectives li::before {
+  content: "✦";
+  margin-right: 0.5rem;
+  color: var(--accent);
+}
+
+.quest-rewards {
+  font-size: 0.9rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+@media (max-width: 960px) {
+  .app {
+    flex-direction: column;
+  }
+
+  .player-panel {
+    position: relative;
+    width: 100%;
+    max-height: none;
+  }
+
+  .main-area {
+    padding-bottom: 4rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/game/game.js
+++ b/game/game.js
@@ -1,0 +1,1429 @@
+(() => {
+  const dataFiles = {
+    classes: './data/classes.json',
+    enemies: './data/enemies.json',
+    zones: './data/zones.json',
+    dungeons: './data/dungeons.json',
+    npcs: './data/npcs.json',
+    items: './data/items.json',
+    professions: './data/professions.json',
+    quests: './data/quests.json'
+  };
+
+  const data = {};
+  const dataIndex = {};
+
+  const state = {
+    player: null,
+    currentScreen: 'exploration',
+    selected: {
+      zoneId: null,
+      dungeonId: null,
+      enemyId: null,
+      npcZoneId: null,
+      npcId: null,
+      merchantId: null,
+      professionId: null,
+      recipeId: null
+    },
+    combat: {
+      enemyId: null,
+      context: null
+    },
+    logs: []
+  };
+
+  const elements = {
+    loading: document.getElementById('loading'),
+    app: document.getElementById('app'),
+    newGameModal: document.getElementById('newGameModal'),
+    newGameForm: document.getElementById('newGameForm'),
+    playerNameInput: document.getElementById('playerNameInput'),
+    classSelect: document.getElementById('classSelect'),
+    classDetails: document.getElementById('classDetails'),
+    inventoryToggle: document.getElementById('inventoryToggle'),
+    questLogToggle: document.getElementById('questLogToggle'),
+    restButton: document.getElementById('restButton'),
+    playerName: document.getElementById('playerName'),
+    playerClass: document.getElementById('playerClass'),
+    playerLevel: document.getElementById('playerLevel'),
+    playerXp: document.getElementById('playerXp'),
+    playerGold: document.getElementById('playerGold'),
+    healthBar: document.getElementById('healthBar'),
+    healthValue: document.getElementById('healthValue'),
+    manaBar: document.getElementById('manaBar'),
+    manaValue: document.getElementById('manaValue'),
+    playerStats: document.getElementById('playerStats'),
+    playerAbilities: document.getElementById('playerAbilities'),
+    playerProfessions: document.getElementById('playerProfessions'),
+    playerEquipment: document.getElementById('playerEquipment'),
+    activityTabs: document.getElementById('activityTabs'),
+    screens: Array.from(document.querySelectorAll('.screen')),
+    logEntries: document.getElementById('logEntries'),
+    inventoryPanel: document.getElementById('inventoryPanel'),
+    inventoryList: document.getElementById('inventoryList'),
+    questLogPanel: document.getElementById('questLogPanel'),
+    questLogContent: document.getElementById('questLogContent'),
+    explorationZoneSelect: document.getElementById('explorationZoneSelect'),
+    explorationZoneDescription: document.getElementById('explorationZoneDescription'),
+    explorationZoneDetails: document.getElementById('explorationZoneDetails'),
+    explorationNPCs: document.getElementById('explorationNPCs'),
+    explorationResources: document.getElementById('explorationResources'),
+    explorationPoints: document.getElementById('explorationPoints'),
+    exploreZoneButton: document.getElementById('exploreZoneButton'),
+    scoutZoneButton: document.getElementById('scoutZoneButton'),
+    dungeonSelect: document.getElementById('dungeonSelect'),
+    dungeonDescription: document.getElementById('dungeonDescription'),
+    dungeonObjectives: document.getElementById('dungeonObjectives'),
+    dungeonEncounters: document.getElementById('dungeonEncounters'),
+    dungeonEffects: document.getElementById('dungeonEffects'),
+    dungeonRewards: document.getElementById('dungeonRewards'),
+    startDungeonButton: document.getElementById('startDungeonButton'),
+    combatZoneSelect: document.getElementById('combatZoneSelect'),
+    combatEnemySelect: document.getElementById('combatEnemySelect'),
+    engageCombatButton: document.getElementById('engageCombatButton'),
+    autoSelectEnemy: document.getElementById('autoSelectEnemy'),
+    enemyDetails: document.getElementById('enemyDetails'),
+    npcZoneSelect: document.getElementById('npcZoneSelect'),
+    npcSelect: document.getElementById('npcSelect'),
+    npcDetails: document.getElementById('npcDetails'),
+    talkToNpcButton: document.getElementById('talkToNpcButton'),
+    requestQuestButton: document.getElementById('requestQuestButton'),
+    merchantSelect: document.getElementById('merchantSelect'),
+    merchantInfo: document.getElementById('merchantInfo'),
+    merchantInventory: document.getElementById('merchantInventory'),
+    sellInventory: document.getElementById('sellInventory'),
+    refreshMerchantButton: document.getElementById('refreshMerchantButton'),
+    professionSelect: document.getElementById('professionSelect'),
+    professionDescription: document.getElementById('professionDescription'),
+    professionGatherables: document.getElementById('professionGatherables'),
+    professionRecipes: document.getElementById('professionRecipes'),
+    gatherButton: document.getElementById('gatherButton'),
+    craftButton: document.getElementById('craftButton'),
+    recipeSelect: document.getElementById('recipeSelect'),
+    inventoryItemTemplate: document.getElementById('inventoryItemTemplate'),
+    recipeTemplate: document.getElementById('recipeTemplate')
+  };
+
+  const overlayToggleButtons = Array.from(document.querySelectorAll('.close-button'));
+
+  const logTypes = {
+    INFO: 'info',
+    SUCCESS: 'success',
+    WARNING: 'warning',
+    DANGER: 'danger'
+  };
+
+  const screenRenderers = {
+    exploration: renderExplorationScreen,
+    dungeons: renderDungeonScreen,
+    combat: renderCombatScreen,
+    npcs: renderNpcScreen,
+    trading: renderTradingScreen,
+    professions: renderProfessionScreen
+  };
+
+  loadWorldData();
+
+  function loadWorldData() {
+    Promise.all(
+      Object.entries(dataFiles).map(([key, path]) =>
+        fetch(path)
+          .then((response) => {
+            if (!response.ok) {
+              throw new Error(`${response.status} ${response.statusText}`);
+            }
+            return response.json();
+          })
+          .then((json) => [key, json])
+      )
+    )
+      .then((entries) => {
+        entries.forEach(([key, value]) => {
+          data[key] = value;
+        });
+        indexData();
+        initialiseUI();
+      })
+      .catch((error) => {
+        console.error(error);
+        elements.loading.textContent = `Failed to load world data: ${error.message}`;
+      });
+  }
+
+  function indexData() {
+    dataIndex.classes = indexById(data.classes);
+    dataIndex.enemies = indexById(data.enemies);
+    dataIndex.zones = indexById(data.zones);
+    dataIndex.dungeons = indexById(data.dungeons);
+    dataIndex.npcs = indexById(data.npcs);
+    dataIndex.items = indexById(data.items);
+    dataIndex.professions = indexById(data.professions);
+    dataIndex.quests = indexById(data.quests);
+  }
+
+  function indexById(collection) {
+    return collection.reduce((acc, item) => {
+      acc[item.id] = item;
+      return acc;
+    }, {});
+  }
+
+  function initialiseUI() {
+    elements.loading.classList.add('hidden');
+    elements.app.classList.remove('hidden');
+    setupNewGameForm();
+    setupNavigation();
+    setupOverlays();
+    setupExplorationControls();
+    setupDungeonControls();
+    setupCombatControls();
+    setupNpcControls();
+    setupTradingControls();
+    setupProfessionControls();
+    elements.restButton.addEventListener('click', restAtCamp);
+    addLog('World data loaded. Create your hero to begin.', logTypes.INFO);
+  }
+
+  function setupNewGameForm() {
+    const classOptions = data.classes
+      .map((cls) => `<option value=\"${cls.id}\">${cls.name}</option>`)
+      .join('');
+    elements.classSelect.innerHTML = `<option value=\"\" disabled selected>Select a class</option>${classOptions}`;
+    elements.classSelect.addEventListener('change', () => {
+      renderClassDetails(elements.classSelect.value);
+    });
+    elements.newGameForm.addEventListener('submit', (event) => {
+      event.preventDefault();
+      startGame();
+    });
+  }
+  function renderClassDetails(classId) {
+    const classData = dataIndex.classes[classId];
+    if (!classData) {
+      elements.classDetails.textContent = 'Select a class to view its details.';
+      return;
+    }
+    const startingItems = [...(classData.startingItems || []), classData.startingArmor]
+      .filter(Boolean)
+      .map((itemId) => dataIndex.items[itemId]?.name || itemId);
+    const statsList = Object.entries(classData.stats)
+      .map(([stat, value]) => `<li><strong>${toTitle(stat)}</strong>: ${value}</li>`)
+      .join('');
+    const abilitiesList = (classData.abilities || [])
+      .map((ability) => `<li>${ability}</li>`)
+      .join('');
+    elements.classDetails.innerHTML = `
+      <h3>${classData.name}</h3>
+      <p>${classData.description}</p>
+      <h4>Role</h4>
+      <p>${classData.role}</p>
+      <h4>Attributes</h4>
+      <ul class=\"bullet-list\">${statsList}</ul>
+      <h4>Signature Abilities</h4>
+      <ul class=\"bullet-list\">${abilitiesList}</ul>
+      <h4>Starting Kit</h4>
+      <p>${startingItems.join(', ') || 'None'}</p>
+    `;
+  }
+
+  function startGame() {
+    const name = elements.playerNameInput.value.trim();
+    const classId = elements.classSelect.value;
+    if (!name) {
+      addLog('Choose a name for your hero before you begin.', logTypes.WARNING);
+      elements.playerNameInput.focus();
+      return;
+    }
+    if (!classId) {
+      addLog('Select a class to determine your hero\'s path.', logTypes.WARNING);
+      elements.classSelect.focus();
+      return;
+    }
+    state.player = createPlayer(name, classId);
+    elements.newGameModal.classList.add('hidden');
+    addLog(`Welcome, ${state.player.name} the ${getClass(classId).name}!`, logTypes.SUCCESS);
+    updateAllUI();
+    showScreen('exploration');
+  }
+
+  function createPlayer(name, classId) {
+    const classData = getClass(classId);
+    const player = {
+      name,
+      classId,
+      level: 1,
+      xp: 0,
+      xpToLevel: 120,
+      gold: classData.startingGold ?? 20,
+      stats: { ...classData.stats },
+      growth: { ...classData.statGrowth },
+      abilities: [...(classData.abilities || [])],
+      inventory: {},
+      equipment: {
+        weapon: null,
+        offHand: null,
+        armor: null,
+        trinket: null
+      },
+      resources: {
+        health: classData.stats.health,
+        mana: classData.stats.mana
+      },
+      professions: [...(classData.startingProfessions || [])],
+      quests: {
+        active: [],
+        completed: []
+      }
+    };
+    if (classData.startingArmor) {
+      grantItem(player, classData.startingArmor, 1, { autoEquip: true });
+    }
+    (classData.startingItems || []).forEach((itemId) => {
+      grantItem(player, itemId, 1, { autoEquip: true });
+    });
+    (classData.startingQuests || []).forEach((questId) => {
+      addQuestToPlayer(player, questId);
+    });
+    syncResourceCaps(player);
+    return player;
+  }
+
+  function setupNavigation() {
+    elements.activityTabs.addEventListener('click', (event) => {
+      const button = event.target.closest('button[data-screen]');
+      if (!button) return;
+      showScreen(button.dataset.screen);
+    });
+  }
+
+  function setupOverlays() {
+    elements.inventoryToggle.addEventListener('click', () => toggleOverlay(elements.inventoryPanel, true));
+    elements.questLogToggle.addEventListener('click', () => toggleOverlay(elements.questLogPanel, true));
+    overlayToggleButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        const targetId = button.dataset.close;
+        const panel = targetId ? document.getElementById(targetId) : button.closest('.overlay-panel');
+        toggleOverlay(panel, false);
+      });
+    });
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape') {
+        [elements.inventoryPanel, elements.questLogPanel].forEach((panel) => toggleOverlay(panel, false));
+      }
+    });
+    elements.inventoryList.addEventListener('click', (event) => {
+      const useButton = event.target.closest('[data-use-item]');
+      if (!useButton || !state.player) return;
+      useItem(useButton.dataset.useItem);
+    });
+    elements.merchantInventory.addEventListener('click', (event) => {
+      const buyButton = event.target.closest('[data-buy-item]');
+      if (!buyButton || !state.player) return;
+      handlePurchase(buyButton.dataset.buyItem);
+    });
+    elements.sellInventory.addEventListener('click', (event) => {
+      const sellButton = event.target.closest('[data-sell-item]');
+      if (!sellButton || !state.player) return;
+      handleSale(sellButton.dataset.sellItem);
+    });
+    elements.professionRecipes.addEventListener('click', (event) => {
+      const craftButton = event.target.closest('[data-craft-item]');
+      if (!craftButton || !state.player) return;
+      craftRecipe(craftButton.dataset.craftItem);
+    });
+  }
+
+  function setupExplorationControls() {
+    elements.explorationZoneSelect.addEventListener('change', () => {
+      state.selected.zoneId = elements.explorationZoneSelect.value;
+      renderExplorationScreen();
+    });
+    elements.exploreZoneButton.addEventListener('click', exploreZone);
+    elements.scoutZoneButton.addEventListener('click', scoutZone);
+  }
+
+  function setupDungeonControls() {
+    elements.dungeonSelect.addEventListener('change', () => {
+      state.selected.dungeonId = elements.dungeonSelect.value;
+      renderDungeonScreen();
+    });
+    elements.startDungeonButton.addEventListener('click', startDungeonRun);
+  }
+
+  function setupCombatControls() {
+    elements.combatZoneSelect.addEventListener('change', () => {
+      state.selected.zoneId = elements.combatZoneSelect.value;
+      populateCombatEnemies();
+    });
+    elements.combatEnemySelect.addEventListener('change', () => {
+      state.selected.enemyId = elements.combatEnemySelect.value;
+      renderEnemyDetails(state.selected.enemyId);
+    });
+    elements.engageCombatButton.addEventListener('click', () => {
+      if (!state.selected.enemyId) {
+        addLog('Select an enemy to engage in combat.', logTypes.WARNING);
+        return;
+      }
+      simulateCombat(state.selected.enemyId);
+    });
+    elements.autoSelectEnemy.addEventListener('click', () => {
+      const zone = getZone(state.selected.zoneId) || data.zones[0];
+      if (!zone) return;
+      const randomEnemy = sample(zone.enemyIds);
+      if (!randomEnemy) {
+        addLog('This region has no known enemies to fight.', logTypes.WARNING);
+        return;
+      }
+      state.selected.enemyId = randomEnemy;
+      elements.combatEnemySelect.value = randomEnemy;
+      renderEnemyDetails(randomEnemy);
+      addLog(`A roaming ${getEnemy(randomEnemy).name} crosses your path.`, logTypes.INFO);
+    });
+  }
+
+  function setupNpcControls() {
+    elements.npcZoneSelect.addEventListener('change', () => {
+      state.selected.npcZoneId = elements.npcZoneSelect.value;
+      populateNpcsForZone();
+    });
+    elements.npcSelect.addEventListener('change', () => {
+      state.selected.npcId = elements.npcSelect.value;
+      renderNpcDetails(state.selected.npcId);
+    });
+    elements.talkToNpcButton.addEventListener('click', talkToNpc);
+    elements.requestQuestButton.addEventListener('click', requestQuestFromNpc);
+  }
+
+  function setupTradingControls() {
+    elements.merchantSelect.addEventListener('change', () => {
+      state.selected.merchantId = elements.merchantSelect.value;
+      renderTradingScreen();
+    });
+    elements.refreshMerchantButton.addEventListener('click', () => {
+      if (!state.selected.merchantId) return;
+      addLog('The merchant refreshes their stock with new wares.', logTypes.INFO);
+      renderTradingScreen(true);
+    });
+  }
+
+  function setupProfessionControls() {
+    elements.professionSelect.addEventListener('change', () => {
+      state.selected.professionId = elements.professionSelect.value;
+      state.selected.recipeId = null;
+      renderProfessionScreen();
+    });
+    elements.recipeSelect.addEventListener('change', () => {
+      state.selected.recipeId = elements.recipeSelect.value;
+    });
+    elements.gatherButton.addEventListener('click', gatherResources);
+    elements.craftButton.addEventListener('click', () => {
+      if (!state.selected.recipeId) {
+        addLog('Select a recipe before attempting to craft.', logTypes.WARNING);
+        return;
+      }
+      craftRecipe(state.selected.recipeId);
+    });
+  }
+  function toggleOverlay(panel, open) {
+    if (!panel) return;
+    panel.classList.toggle('open', open);
+    panel.setAttribute('aria-hidden', open ? 'false' : 'true');
+  }
+
+  function showScreen(screenId) {
+    if (!screenRenderers[screenId]) return;
+    state.currentScreen = screenId;
+    elements.activityTabs.querySelectorAll('button').forEach((button) => {
+      button.classList.toggle('active', button.dataset.screen === screenId);
+    });
+    elements.screens.forEach((screen) => {
+      screen.classList.toggle('active', screen.id === `screen-${screenId}`);
+    });
+    screenRenderers[screenId]();
+  }
+
+  function updateAllUI() {
+    if (!state.player) return;
+    syncResourceCaps(state.player);
+    updatePlayerPanel();
+    renderExplorationScreen();
+    renderDungeonScreen();
+    renderCombatScreen();
+    renderNpcScreen();
+    renderTradingScreen();
+    renderProfessionScreen();
+    updateQuestLogView();
+    renderInventory();
+    renderLog();
+  }
+
+  function syncResourceCaps(player) {
+    const maxHealth = getTotalStat(player, 'health');
+    const maxMana = getTotalStat(player, 'mana');
+    player.resources.health = clamp(player.resources.health ?? maxHealth, 0, maxHealth);
+    player.resources.mana = clamp(player.resources.mana ?? maxMana, 0, maxMana);
+  }
+
+  function updatePlayerPanel() {
+    const player = state.player;
+    const playerClass = getClass(player.classId);
+    const maxHealth = getTotalStat(player, 'health');
+    const maxMana = getTotalStat(player, 'mana');
+    elements.playerName.textContent = player.name;
+    elements.playerClass.textContent = playerClass?.name || '-';
+    elements.playerLevel.textContent = player.level;
+    elements.playerXp.textContent = `${player.xp} / ${player.xpToLevel}`;
+    elements.playerGold.textContent = `${player.gold}`;
+    updateResourceBar(elements.healthBar, elements.healthValue, player.resources.health, maxHealth);
+    updateResourceBar(elements.manaBar, elements.manaValue, player.resources.mana, maxMana);
+    renderPlayerStats();
+    renderPlayerAbilities();
+    renderPlayerProfessions();
+    renderPlayerEquipment();
+  }
+
+  function updateResourceBar(bar, label, current, max) {
+    if (!bar || !label) return;
+    const safeMax = max || 1;
+    const percent = clamp(current / safeMax, 0, 1) * 100;
+    bar.style.width = `${percent}%`;
+    label.textContent = `${Math.round(current)} / ${Math.round(safeMax)}`;
+  }
+
+  function renderPlayerStats() {
+    const player = state.player;
+    const stats = ['health', 'mana', 'strength', 'agility', 'intellect', 'armor'];
+    elements.playerStats.innerHTML = stats
+      .map((stat) => {
+        const base = Math.round(player.stats[stat] || 0);
+        const total = Math.round(getTotalStat(player, stat));
+        const diff = total - base;
+        const bonus = diff !== 0 ? ` (<span class=\"bonus\">${diff > 0 ? '+' : ''}${diff}</span>)` : '';
+        return `<li>${toTitle(stat)}: ${total}${bonus}</li>`;
+      })
+      .join('');
+  }
+
+  function renderPlayerAbilities() {
+    elements.playerAbilities.innerHTML = (state.player.abilities || [])
+      .map((ability) => `<li>${ability}</li>`)
+      .join('') || '<li>No abilities learned yet.</li>';
+  }
+
+  function renderPlayerProfessions() {
+    const professions = state.player.professions || [];
+    elements.playerProfessions.innerHTML = professions
+      .map((id) => {
+        const profession = getProfession(id);
+        if (!profession) return '';
+        const role = profession.type === 'gathering' ? 'Gathering' : 'Crafting';
+        return `<li>${profession.name} <span>(${role})</span></li>`;
+      })
+      .join('') || '<li>No professions trained.</li>';
+  }
+
+  function renderPlayerEquipment() {
+    const equipmentSlots = [
+      ['weapon', 'Weapon'],
+      ['offHand', 'Off-hand'],
+      ['armor', 'Armor'],
+      ['trinket', 'Trinket']
+    ];
+    elements.playerEquipment.innerHTML = equipmentSlots
+      .map(([slot, label]) => {
+        const itemId = state.player.equipment[slot];
+        const item = getItem(itemId);
+        return `<li><span>${label}:</span> ${item ? item.name : 'None'}</li>`;
+      })
+      .join('');
+  }
+
+  function renderExplorationScreen() {
+    populateZoneSelect(elements.explorationZoneSelect);
+    const zone = getZone(state.selected.zoneId) || data.zones[0];
+    if (!zone) return;
+    state.selected.zoneId = zone.id;
+    elements.explorationZoneSelect.value = zone.id;
+    elements.explorationZoneDescription.textContent = zone.description;
+    elements.explorationZoneDetails.innerHTML = `
+      <li>Climate: ${zone.climate}</li>
+      <li>Level Range: ${zone.levelRange[0]} - ${zone.levelRange[1]}</li>
+    `;
+    elements.explorationPoints.innerHTML = (zone.pointsOfInterest || [])
+      .map((poi) => `<p>${poi}</p>`)
+      .join('') || '<p>No notable landmarks recorded.</p>';
+    elements.explorationNPCs.innerHTML = (zone.npcIds || [])
+      .map((npcId) => `<li>${getNpc(npcId)?.name || npcId}</li>`)
+      .join('') || '<li>No allies reported.</li>';
+    elements.explorationResources.innerHTML = (zone.gatherables || [])
+      .map((itemId) => `<li>${getItem(itemId)?.name || itemId}</li>`)
+      .join('') || '<li>No gatherable resources.</li>';
+  }
+
+  function populateZoneSelect(selectElement) {
+    if (!selectElement || !data.zones.length) return;
+    const options = data.zones.map((zone) => `<option value=\"${zone.id}\">${zone.name}</option>`).join('');
+    selectElement.innerHTML = options;
+    if (!state.selected.zoneId) {
+      state.selected.zoneId = data.zones[0]?.id || null;
+    }
+  }
+
+  function exploreZone() {
+    if (!state.player) return;
+    const zone = getZone(state.selected.zoneId);
+    if (!zone) return;
+    if (state.player.resources.health <= 0) {
+      addLog('You are too wounded to explore. Rest first.', logTypes.WARNING);
+      return;
+    }
+    const roll = Math.random();
+    if (roll < 0.45 && zone.enemyIds?.length) {
+      const enemyId = sample(zone.enemyIds);
+      addLog(`You encounter a ${getEnemy(enemyId).name}!`, logTypes.WARNING);
+      startCombat(enemyId, { zoneId: zone.id });
+    } else if (roll < 0.7 && zone.gatherables?.length) {
+      const gatheredItem = sample(zone.gatherables);
+      const amount = Math.random() < 0.3 ? 2 : 1;
+      grantItem(state.player, gatheredItem, amount);
+      addLog(`You gather ${amount} ${getItem(gatheredItem).name}.`, logTypes.SUCCESS);
+      renderInventory();
+      updateQuestProgress('collect', gatheredItem, amount);
+    } else if (roll < 0.85 && zone.npcIds?.length) {
+      const npcId = sample(zone.npcIds);
+      addLog(`You come across ${getNpc(npcId).name}.`, logTypes.INFO);
+      state.selected.npcId = npcId;
+      showScreen('npcs');
+    } else {
+      addLog('You discover ancient carvings detailing forgotten lore.', logTypes.INFO);
+    }
+  }
+
+  function scoutZone() {
+    const zone = getZone(state.selected.zoneId);
+    if (!zone) return;
+    const enemies = (zone.enemyIds || []).map((id) => getEnemy(id)?.name || id).join(', ');
+    const dungeonNames = (zone.dungeonIds || []).map((id) => getDungeon(id)?.name || id).join(', ');
+    addLog(
+      `Scouting report for ${zone.name}: Enemies [${enemies || 'Unknown'}], Dungeons [${dungeonNames || 'None'}].`,
+      logTypes.INFO
+    );
+  }
+
+  function renderDungeonScreen() {
+    populateDungeonSelect();
+    const dungeon = getDungeon(state.selected.dungeonId) || data.dungeons[0];
+    if (!dungeon) return;
+    state.selected.dungeonId = dungeon.id;
+    elements.dungeonSelect.value = dungeon.id;
+    elements.dungeonDescription.textContent = dungeon.description;
+    elements.dungeonObjectives.innerHTML = (dungeon.objectives || [])
+      .map((objective) => `<li>${objective}</li>`)
+      .join('') || '<li>No recorded objectives.</li>';
+    elements.dungeonEncounters.innerHTML = (dungeon.encounterIds || [])
+      .map((enemyId) => `<li>${getEnemy(enemyId)?.name || enemyId}</li>`)
+      .join('') || '<li>No scouting data.</li>';
+    elements.dungeonEffects.innerHTML = (dungeon.environmentalEffects || [])
+      .map((effect) => `<li>${effect}</li>`)
+      .join('') || '<li>None.</li>';
+    elements.dungeonRewards.innerHTML = `
+      <li>Experience: ${dungeon.rewards?.xp ?? 0}</li>
+      <li>Gold: ${dungeon.rewards?.gold ?? 0}</li>
+      <li>Items: ${(dungeon.rewards?.items || []).map((id) => getItem(id)?.name || id).join(', ') || 'None'}</li>
+    `;
+  }
+  function populateDungeonSelect() {
+    if (!data.dungeons.length) {
+      elements.dungeonSelect.innerHTML = '<option>No dungeons discovered</option>';
+      return;
+    }
+    elements.dungeonSelect.innerHTML = data.dungeons
+      .map((dungeon) => `<option value=\"${dungeon.id}\">${dungeon.name}</option>`)
+      .join('');
+    if (!state.selected.dungeonId) {
+      state.selected.dungeonId = data.dungeons[0].id;
+    }
+  }
+
+  function startDungeonRun() {
+    if (!state.player) return;
+    const dungeon = getDungeon(state.selected.dungeonId);
+    if (!dungeon) return;
+    addLog(`You delve into the ${dungeon.name}.`, logTypes.INFO);
+    const encounters = [...(dungeon.encounterIds || [])];
+    if (dungeon.bossId) encounters.push(dungeon.bossId);
+    const enemyId = sample(encounters);
+    startCombat(enemyId, { dungeonId: dungeon.id, boss: enemyId === dungeon.bossId });
+  }
+
+  function renderCombatScreen() {
+    populateZoneSelect(elements.combatZoneSelect);
+    const zone = getZone(state.selected.zoneId) || data.zones[0];
+    if (!zone) return;
+    elements.combatZoneSelect.value = zone.id;
+    populateCombatEnemies();
+    renderEnemyDetails(state.selected.enemyId);
+  }
+
+  function populateCombatEnemies() {
+    const zone = getZone(state.selected.zoneId);
+    if (!zone) {
+      elements.combatEnemySelect.innerHTML = '';
+      return;
+    }
+    const enemies = zone.enemyIds || [];
+    elements.combatEnemySelect.innerHTML = enemies
+      .map((enemyId) => `<option value=\"${enemyId}\">${getEnemy(enemyId).name}</option>`)
+      .join('');
+    if (!enemies.length) {
+      elements.combatEnemySelect.innerHTML = '<option>No threats mapped</option>';
+      state.selected.enemyId = null;
+      return;
+    }
+    if (!state.selected.enemyId || !enemies.includes(state.selected.enemyId)) {
+      state.selected.enemyId = enemies[0];
+    }
+    elements.combatEnemySelect.value = state.selected.enemyId;
+  }
+
+  function renderEnemyDetails(enemyId) {
+    const enemy = getEnemy(enemyId);
+    if (!enemy) {
+      elements.enemyDetails.textContent = 'Select an enemy to view scouting intel.';
+      return;
+    }
+    const loot = (enemy.loot || [])
+      .map((entry) => `${getItem(entry.itemId)?.name || entry.itemId} (${Math.round(entry.chance * 100)}%)`)
+      .join(', ');
+    elements.enemyDetails.innerHTML = `
+      <p><strong>Level:</strong> ${enemy.level}</p>
+      <p><strong>Type:</strong> ${toTitle(enemy.type)}</p>
+      <p><strong>Vitals:</strong> ${enemy.stats.health} health, ${enemy.stats.power} power, ${enemy.stats.defense} defense</p>
+      <p><strong>Abilities:</strong> ${(enemy.abilities || []).join(', ') || 'Unknown'}</p>
+      <p><strong>Loot:</strong> ${loot || 'None noted'}</p>
+    `;
+  }
+
+  function startCombat(enemyId, context = null) {
+    state.combat.enemyId = enemyId;
+    state.combat.context = context;
+    state.selected.enemyId = enemyId;
+    showScreen('combat');
+    renderCombatScreen();
+  }
+
+  function simulateCombat(enemyId) {
+    const player = state.player;
+    const enemy = getEnemy(enemyId);
+    if (!player || !enemy) return;
+    if (player.resources.health <= 0) {
+      addLog('You must recover before entering battle.', logTypes.WARNING);
+      return;
+    }
+    let playerHealth = player.resources.health;
+    let playerMana = player.resources.mana;
+    let enemyHealth = enemy.stats.health;
+    const playerAttack = calculatePlayerAttack();
+    const playerDefense = getTotalStat(player, 'armor');
+    const rounds = [];
+    let roundCount = 0;
+    while (playerHealth > 0 && enemyHealth > 0 && roundCount < 20) {
+      roundCount += 1;
+      const playerDamage = Math.max(4, Math.round(playerAttack * (0.9 + Math.random() * 0.3) - enemy.stats.defense));
+      enemyHealth -= playerDamage;
+      rounds.push(`You strike the ${enemy.name} for ${playerDamage} damage.`);
+      if (enemyHealth <= 0) break;
+      const enemyDamage = Math.max(3, Math.round(enemy.stats.power * (0.9 + Math.random() * 0.3) - playerDefense));
+      playerHealth -= enemyDamage;
+      rounds.push(`The ${enemy.name} hits you for ${enemyDamage} damage.`);
+      if (playerMana > 10 && Math.random() < 0.3) {
+        playerMana -= 10;
+        const abilityDamage = Math.round(playerAttack * 0.6 + 8);
+        enemyHealth -= abilityDamage;
+        rounds.push(`You unleash an ability dealing ${abilityDamage} extra damage.`);
+      }
+    }
+    player.resources.health = Math.max(0, playerHealth);
+    player.resources.mana = clamp(playerMana, 0, getTotalStat(player, 'mana'));
+    if (enemyHealth <= 0 && playerHealth > 0) {
+      handleCombatVictory(enemy, rounds);
+    } else if (playerHealth <= 0) {
+      handleCombatDefeat(enemy, rounds);
+    } else {
+      addLog('The clash ends inconclusively as both sides withdraw.', logTypes.INFO);
+      rounds.forEach((line) => addLog(line, logTypes.INFO));
+    }
+    renderLog();
+    updatePlayerPanel();
+    renderInventory();
+    updateQuestLogView();
+  }
+
+  function handleCombatVictory(enemy, rounds) {
+    rounds.forEach((line) => addLog(line, logTypes.INFO));
+    addLog(`You defeat the ${enemy.name}!`, logTypes.SUCCESS);
+    const xpGained = enemy.xp || 0;
+    const goldGained = enemy.gold || 0;
+    state.player.xp += xpGained;
+    state.player.gold += goldGained;
+    addLog(`Rewards: ${xpGained} XP, ${goldGained} gold.`, logTypes.SUCCESS);
+    (enemy.loot || []).forEach((entry) => {
+      if (Math.random() <= entry.chance) {
+        const quantity = entry.quantity || 1;
+        grantItem(state.player, entry.itemId, quantity);
+        addLog(`Loot acquired: ${getItem(entry.itemId).name} x${quantity}.`, logTypes.SUCCESS);
+      }
+    });
+    updateQuestProgress('kill', enemy.id, 1);
+    checkLevelUp();
+    const context = state.combat.context;
+    if (context?.dungeonId && context.boss) {
+      completeDungeon(context.dungeonId);
+    }
+    state.combat.context = null;
+  }
+
+  function handleCombatDefeat(enemy, rounds) {
+    rounds.forEach((line) => addLog(line, logTypes.DANGER));
+    addLog(`You fall in battle against the ${enemy.name}.`, logTypes.DANGER);
+    const lostGold = Math.min(state.player.gold, Math.max(2, Math.round(state.player.gold * 0.1)));
+    state.player.gold -= lostGold;
+    state.player.resources.health = Math.max(1, Math.round(getTotalStat(state.player, 'health') * 0.25));
+    addLog(`You retreat to safety, losing ${lostGold} gold in the process.`, logTypes.WARNING);
+    state.combat.context = null;
+  }
+
+  function completeDungeon(dungeonId) {
+    const dungeon = getDungeon(dungeonId);
+    if (!dungeon) return;
+    addLog(`Dungeon cleared: ${dungeon.name}!`, logTypes.SUCCESS);
+    state.player.xp += dungeon.rewards?.xp || 0;
+    state.player.gold += dungeon.rewards?.gold || 0;
+    (dungeon.rewards?.items || []).forEach((itemId) => grantItem(state.player, itemId, 1));
+    updateQuestProgress('dungeon', dungeonId, 1);
+    checkLevelUp();
+  }
+
+  function calculatePlayerAttack() {
+    const player = state.player;
+    const base = player.stats.strength + player.stats.agility * 0.5 + player.stats.intellect * 0.3;
+    const equipmentBonus = ['weapon', 'offHand', 'trinket']
+      .map((slot) => getItem(player.equipment[slot]))
+      .filter(Boolean)
+      .reduce((sum, item) => sum + (item.stats?.attack || item.stats?.spellPower || 0), 0);
+    return base + equipmentBonus + player.level * 1.5;
+  }
+
+  function renderNpcScreen() {
+    populateNpcZones();
+    populateNpcsForZone();
+    renderNpcDetails(state.selected.npcId);
+  }
+
+  function populateNpcZones() {
+    const zoneOptions = Array.from(new Set(data.npcs.map((npc) => npc.zoneId)))
+      .filter(Boolean)
+      .map((zoneId) => `<option value=\"${zoneId}\">${getZone(zoneId)?.name || zoneId}</option>`)
+      .join('');
+    elements.npcZoneSelect.innerHTML = zoneOptions;
+    if (!state.selected.npcZoneId) {
+      state.selected.npcZoneId = data.npcs[0]?.zoneId || data.zones[0]?.id || null;
+    }
+    if (state.selected.npcZoneId) {
+      elements.npcZoneSelect.value = state.selected.npcZoneId;
+    }
+  }
+
+  function populateNpcsForZone() {
+    const zoneId = state.selected.npcZoneId;
+    const npcs = data.npcs.filter((npc) => npc.zoneId === zoneId);
+    elements.npcSelect.innerHTML = npcs
+      .map((npc) => `<option value=\"${npc.id}\">${npc.name}</option>`)
+      .join('');
+    if (!state.selected.npcId || !npcs.some((npc) => npc.id === state.selected.npcId)) {
+      state.selected.npcId = npcs[0]?.id || null;
+    }
+    if (state.selected.npcId) {
+      elements.npcSelect.value = state.selected.npcId;
+    }
+  }
+
+  function renderNpcDetails(npcId) {
+    const npc = getNpc(npcId);
+    if (!npc) {
+      elements.npcDetails.textContent = 'Select an ally to review their services.';
+      return;
+    }
+    const services = (npc.services || []).join(', ') || 'None';
+    const dialogue = sample(npc.dialogue || []) || '...';
+    elements.npcDetails.innerHTML = `
+      <p><strong>${npc.name}</strong> — ${npc.title}</p>
+      <p><strong>Faction:</strong> ${npc.faction || 'Independent'}</p>
+      <p><strong>Services:</strong> ${services}</p>
+      <p><strong>They say:</strong> “${dialogue}”</p>
+    `;
+  }
+
+  function talkToNpc() {
+    const npc = getNpc(state.selected.npcId);
+    if (!npc) return;
+    const line = sample(npc.dialogue || []) || `${npc.name} nods silently.`;
+    addLog(`${npc.name} says: “${line}”`, logTypes.INFO);
+    updateQuestProgress('talk', npc.id, 1);
+  }
+
+  function requestQuestFromNpc() {
+    const npc = getNpc(state.selected.npcId);
+    if (!npc) return;
+    const availableQuest = (npc.questIds || []).find((questId) => !hasQuest(questId));
+    if (!availableQuest) {
+      addLog(`${npc.name} has no new tasks for you right now.`, logTypes.INFO);
+      return;
+    }
+    addQuestToPlayer(state.player, availableQuest);
+    updateQuestLogView();
+    addLog(`${npc.name} entrusts you with the quest \"${getQuest(availableQuest).name}\".`, logTypes.SUCCESS);
+  }
+
+  function hasQuest(questId) {
+    return (
+      state.player.quests.active.some((entry) => entry.quest.id === questId) ||
+      state.player.quests.completed.some((entry) => entry.quest.id === questId)
+    );
+  }
+
+  function renderTradingScreen(forceRefresh = false) {
+    populateMerchants();
+    const merchant = getNpc(state.selected.merchantId);
+    if (!merchant) {
+      elements.merchantInfo.textContent = 'Select a merchant to view their wares.';
+      elements.merchantInventory.innerHTML = '';
+      elements.sellInventory.innerHTML = '';
+      return;
+    }
+    elements.merchantInfo.innerHTML = `
+      <p><strong>${merchant.name}</strong> — ${merchant.title}</p>
+      <p><strong>Services:</strong> ${(merchant.services || []).join(', ')}</p>
+      <p><strong>Buys:</strong> ${(merchant.buyTypes || []).join(', ') || 'Common goods'}</p>
+    `;
+    renderMerchantStock(merchant, forceRefresh);
+    renderSellableItems(merchant);
+  }
+
+  function populateMerchants() {
+    const merchants = data.npcs.filter((npc) => (npc.services || []).includes('trading'));
+    if (!merchants.length) {
+      elements.merchantSelect.innerHTML = '<option>No merchants available</option>';
+      return;
+    }
+    elements.merchantSelect.innerHTML = merchants
+      .map((npc) => `<option value=\"${npc.id}\">${npc.name}</option>`)
+      .join('');
+    if (!state.selected.merchantId || !merchants.some((npc) => npc.id === state.selected.merchantId)) {
+      state.selected.merchantId = merchants[0].id;
+    }
+    elements.merchantSelect.value = state.selected.merchantId;
+  }
+
+  function renderMerchantStock(merchant, forceRefresh) {
+    const stock = merchant.inventory || [];
+    if (forceRefresh) {
+      stock.sort(() => Math.random() - 0.5);
+    }
+    elements.merchantInventory.innerHTML = stock
+      .map((entry) => {
+        const item = getItem(entry.itemId);
+        const price = entry.price ?? item.value ?? 5;
+        return `
+          <article class=\"card\">
+            <header class=\"card-header\">${item.name}</header>
+            <p class=\"card-body\">${item.description}</p>
+            <div class=\"card-footer\">
+              <span>${price} gold</span>
+              <button type=\"button\" data-buy-item=\"${entry.itemId}\">Buy</button>
+            </div>
+          </article>
+        `;
+      })
+      .join('') || '<p>No goods available.</p>';
+  }
+  function renderSellableItems(merchant) {
+    const buyTypes = merchant.buyTypes || [];
+    const items = Object.entries(state.player.inventory)
+      .filter(([itemId, qty]) => qty > 0)
+      .filter(([itemId]) => {
+        const item = getItem(itemId);
+        return buyTypes.includes(item.type) || item.tags?.some((tag) => buyTypes.includes(tag));
+      });
+    elements.sellInventory.innerHTML = items
+      .map(([itemId, qty]) => {
+        const item = getItem(itemId);
+        const price = Math.max(1, Math.round((item.value || 1) * 0.6));
+        return `
+          <article class=\"card\">
+            <header class=\"card-header\">${item.name} ×${qty}</header>
+            <p class=\"card-body\">${item.description}</p>
+            <div class=\"card-footer\">
+              <span>Sell for ${price} gold</span>
+              <button type=\"button\" data-sell-item=\"${itemId}\">Sell</button>
+            </div>
+          </article>
+        `;
+      })
+      .join('') || '<p>No items match this merchant\'s interests.</p>';
+  }
+
+  function renderProfessionScreen() {
+    populateProfessionSelect();
+    const profession = getProfession(state.selected.professionId);
+    if (!profession) {
+      elements.professionDescription.textContent = 'Train a profession to begin gathering or crafting.';
+      elements.professionGatherables.innerHTML = '';
+      elements.professionRecipes.innerHTML = '';
+      elements.recipeSelect.innerHTML = '';
+      return;
+    }
+    elements.professionDescription.textContent = profession.description;
+    elements.professionGatherables.innerHTML = (profession.gatherables || [])
+      .map((itemId) => `<li>${getItem(itemId)?.name || itemId}</li>`)
+      .join('') || '<li>No natural resources known.</li>';
+    const recipes = profession.crafts || [];
+    elements.recipeSelect.innerHTML = recipes
+      .map((recipe) => `<option value=\"${recipe.itemId}\">${getItem(recipe.itemId)?.name || recipe.itemId}</option>`)
+      .join('');
+    if (recipes.length) {
+      if (!state.selected.recipeId || !recipes.some((recipe) => recipe.itemId === state.selected.recipeId)) {
+        state.selected.recipeId = recipes[0].itemId;
+      }
+      elements.recipeSelect.value = state.selected.recipeId;
+    } else {
+      elements.recipeSelect.innerHTML = '<option>No recipes learned</option>';
+      state.selected.recipeId = null;
+    }
+    elements.professionRecipes.innerHTML = recipes
+      .map((recipe) => {
+        const item = getItem(recipe.itemId);
+        const requirements = Object.entries(recipe.requirements || {})
+          .map(([id, qty]) => `${getItem(id)?.name || id} ×${qty}`)
+          .join(', ');
+        return `
+          <article class=\"card\">
+            <header class=\"card-header\">${item.name}</header>
+            <p class=\"card-body\">${recipe.description || item.description}</p>
+            <div class=\"card-footer\">
+              <span>Requires: ${requirements || 'N/A'}</span>
+              <button type=\"button\" data-craft-item=\"${recipe.itemId}\">Craft</button>
+            </div>
+          </article>
+        `;
+      })
+      .join('') || '<p>No recipes available.</p>';
+  }
+
+  function populateProfessionSelect() {
+    const professions = (state.player?.professions || []).map((id) => getProfession(id)).filter(Boolean);
+    if (!professions.length) {
+      elements.professionSelect.innerHTML = '<option>No professions trained</option>';
+      return;
+    }
+    elements.professionSelect.innerHTML = professions
+      .map((profession) => `<option value=\"${profession.id}\">${profession.name}</option>`)
+      .join('');
+    if (!state.selected.professionId || !professions.some((p) => p.id === state.selected.professionId)) {
+      state.selected.professionId = professions[0].id;
+    }
+    elements.professionSelect.value = state.selected.professionId;
+  }
+
+  function gatherResources() {
+    if (!state.player) return;
+    const profession = getProfession(state.selected.professionId);
+    if (!profession || !(profession.gatherables || []).length) {
+      addLog('This profession has no resources to gather.', logTypes.INFO);
+      return;
+    }
+    const zone = getZone(state.selected.zoneId) || data.zones[0];
+    const possible = profession.gatherables.filter((itemId) => zone?.gatherables?.includes(itemId));
+    const itemId = sample(possible.length ? possible : profession.gatherables);
+    const amount = Math.random() < 0.25 ? 2 : 1;
+    grantItem(state.player, itemId, amount);
+    addLog(`You gather ${amount} ${getItem(itemId).name} while working in ${zone?.name || 'the wilds'}.`, logTypes.SUCCESS);
+    renderInventory();
+    updateQuestProgress('collect', itemId, amount);
+  }
+
+  function craftRecipe(itemId) {
+    const profession = getProfession(state.selected.professionId);
+    if (!profession) return;
+    const recipe = (profession.crafts || []).find((entry) => entry.itemId === itemId);
+    if (!recipe) {
+      addLog('Recipe not found.', logTypes.WARNING);
+      return;
+    }
+    if (!hasCraftingMaterials(recipe.requirements)) {
+      addLog('Missing materials for this recipe.', logTypes.WARNING);
+      return;
+    }
+    consumeMaterials(recipe.requirements);
+    grantItem(state.player, recipe.itemId, 1);
+    addLog(`You craft ${getItem(recipe.itemId).name}.`, logTypes.SUCCESS);
+    renderInventory();
+  }
+
+  function hasCraftingMaterials(requirements) {
+    return Object.entries(requirements || {}).every(([itemId, qty]) => {
+      return (state.player.inventory[itemId] || 0) >= qty;
+    });
+  }
+
+  function consumeMaterials(requirements) {
+    Object.entries(requirements || {}).forEach(([itemId, qty]) => {
+      removeItem(state.player, itemId, qty);
+    });
+  }
+
+  function grantItem(player, itemId, amount = 1, options = {}) {
+    if (!itemId) return;
+    const item = getItem(itemId);
+    if (!item) return;
+    player.inventory[itemId] = (player.inventory[itemId] || 0) + amount;
+    if (options.autoEquip) {
+      autoEquip(player, itemId);
+    }
+  }
+
+  function removeItem(player, itemId, amount = 1) {
+    if (!player.inventory[itemId]) return;
+    player.inventory[itemId] = Math.max(0, player.inventory[itemId] - amount);
+  }
+
+  function autoEquip(player, itemId) {
+    const item = getItem(itemId);
+    if (!item) return;
+    switch (item.type) {
+      case 'weapon':
+        if (!player.equipment.weapon) player.equipment.weapon = itemId;
+        break;
+      case 'off-hand':
+        if (!player.equipment.offHand) player.equipment.offHand = itemId;
+        break;
+      case 'armor':
+        if (!player.equipment.armor) player.equipment.armor = itemId;
+        break;
+      case 'trinket':
+        if (!player.equipment.trinket) player.equipment.trinket = itemId;
+        break;
+      default:
+        break;
+    }
+  }
+
+  function renderInventory() {
+    if (!state.player) return;
+    const entries = Object.entries(state.player.inventory).filter(([, qty]) => qty > 0);
+    if (!entries.length) {
+      elements.inventoryList.innerHTML = '<p>Your bags are empty.</p>';
+      return;
+    }
+    const fragment = document.createDocumentFragment();
+    entries.forEach(([itemId, qty]) => {
+      const item = getItem(itemId);
+      const template = elements.inventoryItemTemplate.content.cloneNode(true);
+      const card = template.querySelector('.card');
+      const header = template.querySelector('.card-header');
+      const body = template.querySelector('.card-body');
+      const footer = template.querySelector('.card-footer');
+      header.textContent = `${item.name} ×${qty}`;
+      body.textContent = item.description;
+      const value = item.value ? `${item.value} gold` : 'No market value';
+      footer.innerHTML = `<span>${value}</span>`;
+      if (item.type === 'consumable') {
+        const useButton = document.createElement('button');
+        useButton.type = 'button';
+        useButton.textContent = 'Use';
+        useButton.dataset.useItem = itemId;
+        footer.appendChild(useButton);
+      }
+      fragment.appendChild(card);
+    });
+    elements.inventoryList.innerHTML = '';
+    elements.inventoryList.appendChild(fragment);
+  }
+
+  function useItem(itemId) {
+    const item = getItem(itemId);
+    if (!item || item.type !== 'consumable') return;
+    if ((state.player.inventory[itemId] || 0) <= 0) {
+      addLog('You have no more of that item left.', logTypes.WARNING);
+      return;
+    }
+    const effect = item.effect || {};
+    if (effect.health) {
+      state.player.resources.health = clamp(
+        state.player.resources.health + effect.health,
+        0,
+        getTotalStat(state.player, 'health')
+      );
+    }
+    if (effect.mana) {
+      state.player.resources.mana = clamp(
+        state.player.resources.mana + effect.mana,
+        0,
+        getTotalStat(state.player, 'mana')
+      );
+    }
+    removeItem(state.player, itemId, 1);
+    addLog(`You use ${item.name}.`, logTypes.SUCCESS);
+    renderInventory();
+    updatePlayerPanel();
+  }
+
+  function handlePurchase(itemId) {
+    const merchant = getNpc(state.selected.merchantId);
+    if (!merchant) return;
+    const entry = (merchant.inventory || []).find((stock) => stock.itemId === itemId);
+    if (!entry) return;
+    const item = getItem(itemId);
+    const price = entry.price ?? item.value ?? 5;
+    if (state.player.gold < price) {
+      addLog('You cannot afford that purchase.', logTypes.WARNING);
+      return;
+    }
+    state.player.gold -= price;
+    grantItem(state.player, itemId, 1);
+    addLog(`You purchase ${item.name} for ${price} gold.`, logTypes.SUCCESS);
+    renderInventory();
+    updatePlayerPanel();
+  }
+
+  function handleSale(itemId) {
+    const merchant = getNpc(state.selected.merchantId);
+    if (!merchant) return;
+    const quantity = state.player.inventory[itemId] || 0;
+    if (!quantity) {
+      addLog('You have none of that item to sell.', logTypes.WARNING);
+      return;
+    }
+    const item = getItem(itemId);
+    const price = Math.max(1, Math.round((item.value || 1) * 0.6));
+    removeItem(state.player, itemId, 1);
+    state.player.gold += price;
+    addLog(`You sell ${item.name} for ${price} gold.`, logTypes.INFO);
+    renderInventory();
+    updatePlayerPanel();
+    renderTradingScreen();
+  }
+
+  function addQuestToPlayer(player, questId) {
+    const quest = getQuest(questId);
+    if (!quest) return;
+    if (player.quests.active.some((entry) => entry.quest.id === questId)) return;
+    const objectives = (quest.objectives || []).map((objective) => ({
+      ...objective,
+      progress: 0,
+      completed: false
+    }));
+    player.quests.active.push({ quest, objectives });
+  }
+
+  function updateQuestProgress(type, target, amount = 1) {
+    state.player.quests.active.forEach((entry) => {
+      let updated = false;
+      entry.objectives.forEach((objective) => {
+        if (!objective.completed && objective.type === type && objective.target === target) {
+          objective.progress = Math.min(objective.count || 1, (objective.progress || 0) + amount);
+          if (objective.progress >= (objective.count || 1)) {
+            objective.completed = true;
+            addLog(`Objective complete: ${objective.description}`, logTypes.SUCCESS);
+          }
+          updated = true;
+        }
+      });
+      if (updated && entry.objectives.every((objective) => objective.completed)) {
+        completeQuest(entry);
+      }
+    });
+    updateQuestLogView();
+  }
+
+  function completeQuest(entry) {
+    addLog(`Quest complete: ${entry.quest.name}!`, logTypes.SUCCESS);
+    state.player.xp += entry.quest.rewards?.xp || 0;
+    state.player.gold += entry.quest.rewards?.gold || 0;
+    (entry.quest.rewards?.items || []).forEach((itemId) => grantItem(state.player, itemId, 1));
+    state.player.quests.active = state.player.quests.active.filter((active) => active.quest.id !== entry.quest.id);
+    state.player.quests.completed.push(entry);
+    checkLevelUp();
+  }
+
+  function updateQuestLogView() {
+    const fragment = document.createDocumentFragment();
+    const activeHeader = document.createElement('h3');
+    activeHeader.textContent = 'Active Quests';
+    fragment.appendChild(activeHeader);
+    if (!state.player?.quests.active.length) {
+      const empty = document.createElement('p');
+      empty.textContent = 'No active quests.';
+      fragment.appendChild(empty);
+    } else {
+      state.player.quests.active.forEach((entry) => {
+        fragment.appendChild(renderQuestCard(entry, false));
+      });
+    }
+    const completedHeader = document.createElement('h3');
+    completedHeader.textContent = 'Completed Quests';
+    fragment.appendChild(completedHeader);
+    if (!state.player?.quests.completed.length) {
+      const empty = document.createElement('p');
+      empty.textContent = 'No completed quests yet.';
+      fragment.appendChild(empty);
+    } else {
+      state.player.quests.completed.forEach((entry) => {
+        fragment.appendChild(renderQuestCard(entry, true));
+      });
+    }
+    elements.questLogContent.innerHTML = '';
+    elements.questLogContent.appendChild(fragment);
+  }
+
+  function renderQuestCard(entry, completed) {
+    const wrapper = document.createElement('article');
+    wrapper.className = 'quest-card';
+    const header = document.createElement('header');
+    const title = document.createElement('h3');
+    title.textContent = entry.quest.name;
+    const status = document.createElement('span');
+    status.className = 'status';
+    status.textContent = completed ? 'Completed' : 'In Progress';
+    header.appendChild(title);
+    header.appendChild(status);
+    const giver = document.createElement('p');
+    giver.textContent = `Given by ${getNpc(entry.quest.giverId)?.name || 'Unknown'}`;
+    const objectives = document.createElement('ul');
+    objectives.className = 'quest-objectives';
+    entry.objectives.forEach((objective) => {
+      const li = document.createElement('li');
+      const count = objective.count || 1;
+      li.innerHTML = `${objective.description} — ${Math.min(objective.progress, count)}/${count}`;
+      objectives.appendChild(li);
+    });
+    const rewards = document.createElement('p');
+    rewards.className = 'quest-rewards';
+    const items = (entry.quest.rewards?.items || []).map((id) => getItem(id)?.name || id).join(', ');
+    rewards.textContent = `Rewards: ${entry.quest.rewards?.xp || 0} XP, ${entry.quest.rewards?.gold || 0} gold, ${items || 'no items'}`;
+    wrapper.appendChild(header);
+    wrapper.appendChild(giver);
+    wrapper.appendChild(objectives);
+    wrapper.appendChild(rewards);
+    return wrapper;
+  }
+
+  function checkLevelUp() {
+    while (state.player.xp >= state.player.xpToLevel) {
+      state.player.xp -= state.player.xpToLevel;
+      state.player.level += 1;
+      state.player.xpToLevel = Math.round(state.player.xpToLevel * 1.35);
+      levelUpPlayer();
+    }
+    updatePlayerPanel();
+    renderLog();
+  }
+
+  function levelUpPlayer() {
+    const player = state.player;
+    Object.entries(player.growth || {}).forEach(([stat, value]) => {
+      player.stats[stat] = (player.stats[stat] || 0) + value;
+    });
+    player.resources.health = getTotalStat(player, 'health');
+    player.resources.mana = getTotalStat(player, 'mana');
+    addLog(`You reach level ${player.level}! Attributes have improved.`, logTypes.SUCCESS);
+  }
+
+  function renderLog() {
+    elements.logEntries.innerHTML = state.logs
+      .slice(-40)
+      .map((entry) => `<div class=\"log-entry ${entry.type}\">${entry.message}</div>`)
+      .join('');
+  }
+
+  function addLog(message, type = logTypes.INFO) {
+    state.logs.push({ message, type, timestamp: Date.now() });
+    if (state.logs.length > 100) {
+      state.logs.splice(0, state.logs.length - 100);
+    }
+    if (!elements.logEntries) return;
+    const entry = document.createElement('div');
+    entry.className = `log-entry ${type}`;
+    entry.textContent = message;
+    elements.logEntries.appendChild(entry);
+    elements.logEntries.scrollTop = elements.logEntries.scrollHeight;
+  }
+
+  function restAtCamp() {
+    if (!state.player) return;
+    state.player.resources.health = getTotalStat(state.player, 'health');
+    state.player.resources.mana = getTotalStat(state.player, 'mana');
+    addLog('You rest at camp, recovering your strength.', logTypes.INFO);
+    updatePlayerPanel();
+  }
+
+  function getClass(id) {
+    return dataIndex.classes[id];
+  }
+
+  function getEnemy(id) {
+    return dataIndex.enemies[id];
+  }
+
+  function getZone(id) {
+    return dataIndex.zones[id];
+  }
+
+  function getDungeon(id) {
+    return dataIndex.dungeons[id];
+  }
+
+  function getNpc(id) {
+    return dataIndex.npcs[id];
+  }
+
+  function getItem(id) {
+    return dataIndex.items[id];
+  }
+
+  function getProfession(id) {
+    return dataIndex.professions[id];
+  }
+
+  function getQuest(id) {
+    return dataIndex.quests[id];
+  }
+
+  function getTotalStat(player, stat) {
+    const base = player.stats[stat] || 0;
+    const equipmentBonus = Object.values(player.equipment || {})
+      .map((itemId) => getItem(itemId))
+      .filter(Boolean)
+      .reduce((sum, item) => sum + (item.stats?.[stat] || 0), 0);
+    return base + equipmentBonus;
+  }
+
+  function sample(collection) {
+    if (!collection || !collection.length) return null;
+    const index = Math.floor(Math.random() * collection.length);
+    return collection[index];
+  }
+
+  function clamp(value, min, max) {
+    return Math.max(min, Math.min(max, value));
+  }
+
+  function toTitle(value) {
+    return value
+      .replace(/([A-Z])/g, ' $1')
+      .replace(/_/g, ' ')
+      .replace(/^\w/, (c) => c.toUpperCase())
+      .trim();
+  }
+})();

--- a/game/index.html
+++ b/game/index.html
@@ -1,0 +1,283 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Ember Sigil RPG Prototype</title>
+  <link rel="stylesheet" href="./game.css">
+</head>
+<body>
+  <div id="loading" class="loading">Loading world data...</div>
+  <div id="app" class="app hidden" aria-live="polite">
+    <aside class="player-panel" aria-label="Player information">
+      <header class="player-header">
+        <h1>Ember Sigil</h1>
+        <p class="tagline">A data-driven browser RPG prototype</p>
+      </header>
+      <section class="player-summary">
+        <div class="summary-field">
+          <span class="label">Hero</span>
+          <span class="value" id="playerName">-</span>
+        </div>
+        <div class="summary-field">
+          <span class="label">Class</span>
+          <span class="value" id="playerClass">-</span>
+        </div>
+        <div class="summary-field">
+          <span class="label">Level</span>
+          <span class="value" id="playerLevel">1</span>
+        </div>
+        <div class="summary-field">
+          <span class="label">Experience</span>
+          <span class="value" id="playerXp">0 / 0</span>
+        </div>
+        <div class="resource-row" aria-live="polite">
+          <span class="label">Health</span>
+          <div class="resource-bar">
+            <div id="healthBar" class="resource-fill"></div>
+          </div>
+          <span class="value" id="healthValue">0 / 0</span>
+        </div>
+        <div class="resource-row" aria-live="polite">
+          <span class="label">Mana</span>
+          <div class="resource-bar">
+            <div id="manaBar" class="resource-fill mana"></div>
+          </div>
+          <span class="value" id="manaValue">0 / 0</span>
+        </div>
+        <div class="summary-field">
+          <span class="label">Gold</span>
+          <span class="value" id="playerGold">0</span>
+        </div>
+      </section>
+      <div class="player-actions">
+        <button id="inventoryToggle" type="button">Inventory</button>
+        <button id="questLogToggle" type="button">Quest Log</button>
+        <button id="restButton" type="button">Rest at Camp</button>
+      </div>
+      <section class="player-stats" aria-label="Player attributes">
+        <h2>Attributes</h2>
+        <ul id="playerStats"></ul>
+      </section>
+      <section class="player-abilities" aria-label="Equipped abilities">
+        <h2>Abilities</h2>
+        <ul id="playerAbilities"></ul>
+      </section>
+      <section class="player-professions" aria-label="Professions">
+        <h2>Professions</h2>
+        <ul id="playerProfessions"></ul>
+      </section>
+      <section class="player-equipment" aria-label="Equipment">
+        <h2>Equipment</h2>
+        <ul id="playerEquipment"></ul>
+      </section>
+    </aside>
+    <main class="main-area">
+      <nav class="activity-tabs" id="activityTabs" aria-label="Gameplay activities">
+        <button class="active" data-screen="exploration" type="button">Exploration</button>
+        <button data-screen="dungeons" type="button">Dungeons</button>
+        <button data-screen="combat" type="button">Combat</button>
+        <button data-screen="npcs" type="button">NPCs</button>
+        <button data-screen="trading" type="button">Trading</button>
+        <button data-screen="professions" type="button">Professions</button>
+      </nav>
+      <section id="screen-exploration" class="screen active" aria-labelledby="activityTabs">
+        <header>
+          <h2>Explore the World</h2>
+        </header>
+        <div class="screen-grid">
+          <div class="screen-column">
+            <label for="explorationZoneSelect">Zone</label>
+            <select id="explorationZoneSelect"></select>
+            <p id="explorationZoneDescription" class="description"></p>
+            <ul id="explorationZoneDetails" class="bullet-list"></ul>
+            <div class="button-row">
+              <button id="exploreZoneButton" type="button">Explore Zone</button>
+              <button id="scoutZoneButton" type="button">Scout Threats</button>
+            </div>
+          </div>
+          <div class="screen-column">
+            <h3>Connected Locations</h3>
+            <div id="explorationPoints"></div>
+            <h3>Known NPCs</h3>
+            <ul id="explorationNPCs" class="bullet-list"></ul>
+            <h3>Gatherable Resources</h3>
+            <ul id="explorationResources" class="bullet-list"></ul>
+          </div>
+        </div>
+      </section>
+      <section id="screen-dungeons" class="screen" aria-labelledby="activityTabs">
+        <header>
+          <h2>Dungeon Expeditions</h2>
+        </header>
+        <div class="screen-grid">
+          <div class="screen-column">
+            <label for="dungeonSelect">Dungeon</label>
+            <select id="dungeonSelect"></select>
+            <p id="dungeonDescription" class="description"></p>
+            <ul id="dungeonObjectives" class="bullet-list"></ul>
+            <div class="button-row">
+              <button id="startDungeonButton" type="button">Begin Expedition</button>
+            </div>
+          </div>
+          <div class="screen-column">
+            <h3>Encounter Table</h3>
+            <ul id="dungeonEncounters" class="bullet-list"></ul>
+            <h3>Environmental Effects</h3>
+            <ul id="dungeonEffects" class="bullet-list"></ul>
+            <h3>Rewards</h3>
+            <ul id="dungeonRewards" class="bullet-list"></ul>
+          </div>
+        </div>
+      </section>
+      <section id="screen-combat" class="screen" aria-labelledby="activityTabs">
+        <header>
+          <h2>Combat Simulator</h2>
+        </header>
+        <div class="screen-grid">
+          <div class="screen-column">
+            <label for="combatZoneSelect">Region</label>
+            <select id="combatZoneSelect"></select>
+            <label for="combatEnemySelect">Enemy</label>
+            <select id="combatEnemySelect"></select>
+            <div class="button-row">
+              <button id="engageCombatButton" type="button">Engage Enemy</button>
+              <button id="autoSelectEnemy" type="button">Random Encounter</button>
+            </div>
+          </div>
+          <div class="screen-column">
+            <h3>Enemy Intel</h3>
+            <div id="enemyDetails" class="details-card"></div>
+          </div>
+        </div>
+      </section>
+      <section id="screen-npcs" class="screen" aria-labelledby="activityTabs">
+        <header>
+          <h2>NPC Interactions</h2>
+        </header>
+        <div class="screen-grid">
+          <div class="screen-column">
+            <label for="npcZoneSelect">Location</label>
+            <select id="npcZoneSelect"></select>
+            <label for="npcSelect">NPC</label>
+            <select id="npcSelect"></select>
+            <div class="button-row">
+              <button id="talkToNpcButton" type="button">Talk</button>
+              <button id="requestQuestButton" type="button">Request Quest</button>
+            </div>
+          </div>
+          <div class="screen-column">
+            <h3>Personality &amp; Services</h3>
+            <div id="npcDetails" class="details-card"></div>
+          </div>
+        </div>
+      </section>
+      <section id="screen-trading" class="screen" aria-labelledby="activityTabs">
+        <header>
+          <h2>Trading Post</h2>
+        </header>
+        <div class="screen-grid">
+          <div class="screen-column">
+            <label for="merchantSelect">Merchant</label>
+            <select id="merchantSelect"></select>
+            <div class="button-row">
+              <button id="refreshMerchantButton" type="button">Refresh Stock</button>
+            </div>
+            <div id="merchantInfo" class="details-card"></div>
+          </div>
+          <div class="screen-column">
+            <h3>Shop Inventory</h3>
+            <div id="merchantInventory" class="list-grid"></div>
+            <h3>Sellable Goods</h3>
+            <div id="sellInventory" class="list-grid"></div>
+          </div>
+        </div>
+      </section>
+      <section id="screen-professions" class="screen" aria-labelledby="activityTabs">
+        <header>
+          <h2>Professions</h2>
+        </header>
+        <div class="screen-grid">
+          <div class="screen-column">
+            <label for="professionSelect">Profession</label>
+            <select id="professionSelect"></select>
+            <p id="professionDescription" class="description"></p>
+            <label for="recipeSelect">Recipe</label>
+            <select id="recipeSelect"></select>
+            <div class="button-row">
+              <button id="gatherButton" type="button">Gather Resources</button>
+              <button id="craftButton" type="button">Craft Item</button>
+            </div>
+          </div>
+          <div class="screen-column">
+            <h3>Available Gatherables</h3>
+            <ul id="professionGatherables" class="bullet-list"></ul>
+            <h3>Crafting Recipes</h3>
+            <div id="professionRecipes" class="list-grid"></div>
+          </div>
+        </div>
+      </section>
+      <section class="log-panel" aria-live="polite">
+        <h2>Adventure Log</h2>
+        <div id="logEntries" class="log-entries"></div>
+      </section>
+    </main>
+  </div>
+
+  <div id="newGameModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="newGameTitle">
+    <div class="modal-content">
+      <header>
+        <h2 id="newGameTitle">Create Your Hero</h2>
+      </header>
+      <form id="newGameForm">
+        <label for="playerNameInput">Hero Name</label>
+        <input id="playerNameInput" name="playerName" type="text" required maxlength="24" placeholder="Enter a name" autocomplete="off">
+        <label for="classSelect">Class</label>
+        <select id="classSelect" name="classId" required></select>
+        <div id="classDetails" class="details-card"></div>
+        <div class="modal-actions">
+          <button id="startGameButton" type="submit">Begin Adventure</button>
+        </div>
+      </form>
+    </div>
+  </div>
+
+  <div id="inventoryPanel" class="overlay-panel" aria-hidden="true">
+    <div class="overlay-content">
+      <header>
+        <h2>Inventory</h2>
+        <button class="close-button" type="button" data-close="inventoryPanel" aria-label="Close inventory">×</button>
+      </header>
+      <div id="inventoryList" class="list-grid"></div>
+    </div>
+  </div>
+
+  <div id="questLogPanel" class="overlay-panel" aria-hidden="true">
+    <div class="overlay-content">
+      <header>
+        <h2>Quest Log</h2>
+        <button class="close-button" type="button" data-close="questLogPanel" aria-label="Close quest log">×</button>
+      </header>
+      <div id="questLogContent"></div>
+    </div>
+  </div>
+
+  <template id="inventoryItemTemplate">
+    <article class="card">
+      <header class="card-header"></header>
+      <p class="card-body"></p>
+      <div class="card-footer"></div>
+    </article>
+  </template>
+
+  <template id="recipeTemplate">
+    <article class="card">
+      <header class="card-header"></header>
+      <p class="card-body"></p>
+      <div class="card-footer"></div>
+    </article>
+  </template>
+
+  <script src="./game.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,1 +1,0 @@
-<h1>Hello World!<h1>

--- a/index.md
+++ b/index.md
@@ -1,0 +1,8 @@
+---
+layout: default
+title: Home
+---
+
+# Hello, World!
+
+Welcome to the Browser RPG GitHub Pages site. This page was generated with the default Minima theme.


### PR DESCRIPTION
## Summary
- add a dedicated game page with multiple activity screens, player overlays, and interaction templates
- implement the client-side engine that loads JSON data to drive exploration, combat, NPC, trading, and profession systems
- define extensible JSON datasets for classes, items, zones, dungeons, enemies, NPCs, professions, and quests

## Testing
- for f in game/data/*.json; do python -m json.tool "$f"; done

------
https://chatgpt.com/codex/tasks/task_e_68caae35bd38832095266898a741acb3