### PR TITLE
Improve character creation modal layout

### DIFF
--- a/game/game.css
+++ b/game/game.css
@@ -486,15 +486,41 @@ button:disabled {
   justify-content: center;
   background: rgba(5, 7, 11, 0.9);
   z-index: 80;
+  padding: clamp(1.5rem, 4vh, 3rem) 1.5rem;
+  overflow-y: auto;
 }
 
 .modal-content {
   background: rgba(13, 19, 29, 0.95);
-  border-radius: 18px;
-  padding: 2rem;
-  width: min(480px, 90vw);
+  border-radius: 20px;
+  padding: 1.75rem;
+  width: min(560px, 92vw);
+  max-height: min(85vh, 720px);
   box-shadow: var(--shadow);
   border: 1px solid rgba(255, 255, 255, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  overflow: hidden;
+}
+
+.modal-content form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  flex: 1;
+  min-height: 0;
+}
+
+.modal-content .form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.modal-content .form-field select,
+.modal-content .form-field input[type="text"] {
+  margin-bottom: 0;
 }
 
 .modal h2 {
@@ -503,8 +529,220 @@ button:disabled {
 }
 
 .modal-actions {
-  margin-top: 1.25rem;
-  text-align: right;
+  margin-top: auto;
+  display: flex;
+  justify-content: flex-end;
+}
+
+.modal-actions button {
+  min-width: 180px;
+}
+
+.class-details {
+  flex: 1;
+  min-height: 220px;
+  padding: 1.5rem;
+  border-radius: 18px;
+  background: linear-gradient(150deg, rgba(16, 23, 35, 0.95), rgba(10, 14, 20, 0.88));
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  position: relative;
+  overflow: hidden;
+}
+
+.class-details__content {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  overflow-y: auto;
+  padding-right: 0.35rem;
+}
+
+.class-details__content::-webkit-scrollbar {
+  width: 6px;
+}
+
+.class-details__content::-webkit-scrollbar-thumb {
+  background: rgba(148, 163, 184, 0.3);
+  border-radius: 999px;
+}
+
+.class-details__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  gap: 1rem;
+}
+
+.class-details__title {
+  margin: 0;
+  font-size: 1.35rem;
+  letter-spacing: 0.05em;
+}
+
+.class-details__role {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(96, 165, 250, 0.25), rgba(192, 132, 252, 0.2));
+  border: 1px solid rgba(96, 165, 250, 0.35);
+  color: rgba(226, 232, 240, 0.9);
+  white-space: nowrap;
+}
+
+.class-description {
+  margin: 0;
+  color: rgba(226, 232, 240, 0.75);
+  line-height: 1.6;
+  font-size: 0.95rem;
+}
+
+.class-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  background: rgba(7, 11, 19, 0.6);
+  border-radius: 14px;
+  border: 1px solid rgba(94, 234, 212, 0.12);
+  padding: 1rem 1.1rem;
+}
+
+.class-section h4 {
+  margin: 0;
+  font-size: 0.95rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.class-sections-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.class-stat-grid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.class-stat-grid li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.55rem 0.75rem;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.6);
+  font-size: 0.95rem;
+}
+
+.class-stat-grid .stat-name {
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.class-stat-grid .stat-value {
+  font-weight: 600;
+  color: var(--text);
+}
+
+.class-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.5rem;
+}
+
+.class-list li {
+  padding: 0.5rem 0.75rem;
+  border-radius: 10px;
+  background: rgba(30, 41, 59, 0.55);
+  border: 1px solid rgba(59, 130, 246, 0.24);
+  font-size: 0.95rem;
+}
+
+.class-kit {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.class-kit li {
+  padding: 0.45rem 0.8rem;
+  border-radius: 999px;
+  background: rgba(255, 179, 71, 0.18);
+  border: 1px solid rgba(255, 179, 71, 0.35);
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: rgba(252, 252, 252, 0.85);
+}
+
+.class-kit .empty,
+.class-list .empty {
+  background: rgba(15, 23, 42, 0.45);
+  border-style: dashed;
+  color: rgba(148, 163, 184, 0.7);
+}
+
+.class-meta {
+  display: grid;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.class-meta-item {
+  padding: 0.65rem 0.75rem;
+  border-radius: 12px;
+  background: rgba(12, 17, 25, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  display: grid;
+  gap: 0.25rem;
+}
+
+.class-meta-label {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--muted);
+}
+
+.class-meta-value {
+  font-weight: 600;
+  color: var(--text);
+  font-size: 0.95rem;
+}
+
+.class-placeholder {
+  margin: auto;
+  text-align: center;
+  color: rgba(148, 163, 184, 0.8);
+  letter-spacing: 0.04em;
+  line-height: 1.6;
+}
+
+@media (max-width: 520px) {
+  .modal-content {
+    padding: 1.5rem;
+    width: 100%;
+  }
+
+  .class-details {
+    padding: 1.25rem;
+  }
 }
 
 .overlay-panel {

--- a/game/game.js
+++ b/game/game.js
@@ -215,6 +215,7 @@
       .map((cls) => `<option value=\"${cls.id}\">${cls.name}</option>`)
       .join('');
     elements.classSelect.innerHTML = `<option value=\"\" disabled selected>Select a class</option>${classOptions}`;
+    elements.classDetails.innerHTML = '<p class="class-placeholder">Select a class to preview their role, strengths, and starting kit.</p>';
     elements.classSelect.addEventListener('change', () => {
       renderClassDetails(elements.classSelect.value);
     });
@@ -226,29 +227,68 @@
   function renderClassDetails(classId) {
     const classData = dataIndex.classes[classId];
     if (!classData) {
-      elements.classDetails.textContent = 'Select a class to view its details.';
+      elements.classDetails.innerHTML = '<p class="class-placeholder">Select a class to preview their role, strengths, and starting kit.</p>';
       return;
     }
     const startingItems = [...(classData.startingItems || []), classData.startingArmor]
       .filter(Boolean)
       .map((itemId) => dataIndex.items[itemId]?.name || itemId);
-    const statsList = Object.entries(classData.stats)
-      .map(([stat, value]) => `<li><strong>${toTitle(stat)}</strong>: ${value}</li>`)
+    const statsList = Object.entries(classData.stats || {})
+      .map(
+        ([stat, value]) => `
+          <li>
+            <span class=\"stat-name\">${toTitle(stat)}</span>
+            <span class=\"stat-value\">${value}</span>
+          </li>
+        `
+      )
       .join('');
     const abilitiesList = (classData.abilities || [])
       .map((ability) => `<li>${ability}</li>`)
       .join('');
+    const kitList = startingItems.length
+      ? startingItems.map((item) => `<li>${item}</li>`).join('')
+      : '<li class="empty">None</li>';
+    const professions = (classData.startingProfessions || [])
+      .map((id) => dataIndex.professions?.[id]?.name || toTitle(id));
+    const quests = (classData.startingQuests || [])
+      .map((id) => dataIndex.quests?.[id]?.name || toTitle(id));
     elements.classDetails.innerHTML = `
-      <h3>${classData.name}</h3>
-      <p>${classData.description}</p>
-      <h4>Role</h4>
-      <p>${classData.role}</p>
-      <h4>Attributes</h4>
-      <ul class=\"bullet-list\">${statsList}</ul>
-      <h4>Signature Abilities</h4>
-      <ul class=\"bullet-list\">${abilitiesList}</ul>
-      <h4>Starting Kit</h4>
-      <p>${startingItems.join(', ') || 'None'}</p>
+      <div class=\"class-details__content\">
+        <header class=\"class-details__header\">
+          <h3 class=\"class-details__title\">${classData.name}</h3>
+          <span class=\"class-details__role\">${classData.role || 'Adventurer'}</span>
+        </header>
+        <p class=\"class-description\">${classData.description}</p>
+        <div class=\"class-sections-grid\">
+          <section class=\"class-section\">
+            <h4>Attributes</h4>
+            <ul class=\"class-stat-grid\">${statsList || '<li class="empty">No attributes listed</li>'}</ul>
+          </section>
+          <section class=\"class-section\">
+            <h4>Signature Abilities</h4>
+            <ul class=\"class-list\">${abilitiesList || '<li class="empty">No signature abilities listed</li>'}</ul>
+          </section>
+        </div>
+        <section class=\"class-section\">
+          <h4>Starting Kit</h4>
+          <ul class=\"class-kit\">${kitList}</ul>
+          <div class=\"class-meta\">
+            <div class=\"class-meta-item\">
+              <span class=\"class-meta-label\">Starting Gold</span>
+              <span class=\"class-meta-value\">${classData.startingGold ?? 0}</span>
+            </div>
+            <div class=\"class-meta-item\">
+              <span class=\"class-meta-label\">Professions</span>
+              <span class=\"class-meta-value\">${professions.length ? professions.join(', ') : 'None'}</span>
+            </div>
+            <div class=\"class-meta-item\">
+              <span class=\"class-meta-label\">Quests</span>
+              <span class=\"class-meta-value\">${quests.length ? quests.join(', ') : 'None'}</span>
+            </div>
+          </div>
+        </section>
+      </div>
     `;
   }
 

--- a/game/index.html
+++ b/game/index.html
@@ -266,11 +266,15 @@
         <h2 id="newGameTitle">Create Your Hero</h2>
       </header>
       <form id="newGameForm">
-        <label for="playerNameInput">Hero Name</label>
-        <input id="playerNameInput" name="playerName" type="text" required maxlength="24" placeholder="Enter a name" autocomplete="off">
-        <label for="classSelect">Class</label>
-        <select id="classSelect" name="classId" required></select>
-        <div id="classDetails" class="details-card"></div>
+        <div class="form-field">
+          <label for="playerNameInput">Hero Name</label>
+          <input id="playerNameInput" name="playerName" type="text" required maxlength="24" placeholder="Enter a name" autocomplete="off">
+        </div>
+        <div class="form-field">
+          <label for="classSelect">Class</label>
+          <select id="classSelect" name="classId" required></select>
+        </div>
+        <div id="classDetails" class="class-details" aria-live="polite"></div>
         <div class="modal-actions">
           <button id="startGameButton" type="submit">Begin Adventure</button>
         </div>


### PR DESCRIPTION
## Summary
- restyle the new hero modal so it stays within the viewport and has clearer spacing
- redesign the class preview with structured sections for description, attributes, abilities, and starting kit metadata
- show a helpful placeholder message before a class is selected

## Testing
- python3 -m http.server 8000 (manual UI verification)


------
https://chatgpt.com/codex/tasks/task_e_68cac5eb74208320b637418a0f001a2e