### PR TITLE
Add responsive mobile layout with collapsible player panel

### DIFF
--- a/game/game.css
+++ b/game/game.css
@@ -28,6 +28,10 @@ body {
   min-height: 100vh;
 }
 
+body.no-scroll {
+  overflow: hidden;
+}
+
 .loading {
   position: fixed;
   inset: 0;
@@ -48,6 +52,12 @@ body {
   display: flex;
   min-height: 100vh;
   width: 100%;
+}
+
+.player-panel-toggle,
+.player-panel-close,
+.player-panel-backdrop {
+  display: none;
 }
 
 .player-panel {
@@ -849,16 +859,222 @@ button:disabled {
 @media (max-width: 960px) {
   .app {
     flex-direction: column;
+    position: relative;
+    min-height: 100vh;
   }
 
   .player-panel {
-    position: relative;
-    width: 100%;
-    max-height: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: min(320px, 85vw);
+    transform: translateX(-100%);
+    transition: transform 0.25s ease;
+    padding: 2.25rem 1.25rem 1.75rem;
+    border-right: 1px solid var(--panel-border);
+    border-radius: 0 20px 20px 0;
+    z-index: 90;
+    box-shadow: 12px 0 30px rgba(0, 0, 0, 0.45);
+  }
+
+  .app.player-panel-open .player-panel {
+    transform: translateX(0);
+  }
+
+  .player-panel-close {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    position: absolute;
+    top: 0.75rem;
+    right: 0.75rem;
+    width: 2.25rem;
+    height: 2.25rem;
+    border-radius: 999px;
+    border: none;
+    background: rgba(15, 23, 42, 0.45);
+    color: var(--muted);
+    font-size: 1.5rem;
+    line-height: 1;
+    cursor: pointer;
+    transition: background 0.2s ease, color 0.2s ease;
+  }
+
+  .player-panel-close:hover,
+  .player-panel-close:focus-visible {
+    color: var(--accent);
+    background: rgba(148, 163, 184, 0.2);
+  }
+
+  .player-panel-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.55rem;
+    flex: 0 0 auto;
+    padding: 0.65rem 1.1rem;
+    border-radius: 999px;
+    background: rgba(59, 130, 246, 0.18);
+    border: 1px solid rgba(59, 130, 246, 0.35);
+    color: var(--text);
+    font-weight: 600;
+    letter-spacing: 0.04em;
+    box-shadow: var(--shadow);
+    position: sticky;
+    left: 0;
+    z-index: 1;
+    margin-right: 0.35rem;
+    backdrop-filter: blur(10px);
+    background-image: linear-gradient(135deg, rgba(59, 130, 246, 0.25), rgba(59, 130, 246, 0.15));
+    border-color: rgba(59, 130, 246, 0.45);
+  }
+
+  .player-panel-toggle .icon {
+    font-size: 1.15rem;
+  }
+
+  .activity-tabs {
+    overflow-x: auto;
+    padding: 0.65rem 1rem;
+    gap: 0.5rem;
+  }
+
+  .activity-tabs button {
+    flex: 0 0 auto;
+    white-space: nowrap;
+  }
+
+  .activity-tabs::-webkit-scrollbar {
+    height: 6px;
+  }
+
+  .activity-tabs::-webkit-scrollbar-thumb {
+    background: rgba(59, 130, 246, 0.3);
+    border-radius: 999px;
+  }
+
+  .player-panel-backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    background: rgba(8, 12, 19, 0.75);
+    z-index: 80;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.25s ease;
+  }
+
+  .app.player-panel-open .player-panel-backdrop {
+    opacity: 1;
+    pointer-events: auto;
   }
 
   .main-area {
     padding-bottom: 4rem;
+  }
+
+  .screen {
+    padding: 1.25rem 1rem 1.5rem;
+  }
+
+  .screen-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .button-row {
+    flex-direction: column;
+  }
+
+  .log-panel {
+    margin: 0 1rem 1.5rem;
+  }
+}
+
+@media (max-width: 720px) {
+  :root {
+    font-size: 15px;
+  }
+
+  .player-panel {
+    width: min(320px, 92vw);
+    padding: 2.5rem 1.1rem 1.5rem;
+  }
+
+  .player-panel-toggle {
+    padding: 0.6rem 0.95rem;
+  }
+
+  .player-summary,
+  .player-actions,
+  .player-stats,
+  .player-abilities,
+  .player-professions,
+  .player-equipment {
+    padding: 0.85rem;
+  }
+
+  .screen {
+    padding: 1.15rem 0.9rem 1.35rem;
+  }
+
+  .screen-column {
+    padding: 1rem;
+  }
+
+  .list-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .log-panel {
+    margin: 0 0.75rem 1.25rem;
+    padding: 1.05rem 1.15rem;
+  }
+}
+
+@media (max-width: 520px) {
+  :root {
+    font-size: 14px;
+  }
+
+  .player-panel {
+    width: min(360px, 94vw);
+  }
+
+  .player-panel-toggle {
+    padding: 0.55rem 0.75rem;
+    gap: 0.35rem;
+  }
+
+  .player-panel-toggle .label {
+    display: none;
+  }
+
+  .player-panel-toggle .icon {
+    font-size: 1.2rem;
+  }
+
+  .activity-tabs {
+    padding: 0.6rem 0.75rem;
+  }
+
+  .screen {
+    padding: 1rem 0.75rem 1.25rem;
+  }
+
+  .button-row {
+    gap: 0.6rem;
+  }
+
+  .player-actions {
+    flex-direction: column;
+  }
+
+  .player-actions button {
+    width: 100%;
+  }
+
+  .log-panel {
+    margin: 0 0.6rem 1.25rem;
   }
 }
 

--- a/game/game.js
+++ b/game/game.js
@@ -44,6 +44,10 @@
     playerNameInput: document.getElementById('playerNameInput'),
     classSelect: document.getElementById('classSelect'),
     classDetails: document.getElementById('classDetails'),
+    playerPanel: document.getElementById('playerPanel'),
+    playerPanelToggle: document.getElementById('playerPanelToggle'),
+    playerPanelClose: document.getElementById('playerPanelClose'),
+    playerPanelBackdrop: document.getElementById('playerPanelBackdrop'),
     inventoryToggle: document.getElementById('inventoryToggle'),
     questLogToggle: document.getElementById('questLogToggle'),
     restButton: document.getElementById('restButton'),
@@ -191,6 +195,7 @@
   function initialiseUI() {
     elements.loading.classList.add('hidden');
     elements.app.classList.remove('hidden');
+    setupMobileLayout();
     setupNewGameForm();
     setupNavigation();
     setupOverlays();
@@ -367,6 +372,82 @@
       showScreen(button.dataset.screen);
     });
     updateNavigationLocks();
+  }
+
+  function setupMobileLayout() {
+    const { playerPanel, playerPanelToggle, playerPanelClose, playerPanelBackdrop, app } = elements;
+    if (!playerPanel || !playerPanelToggle || !playerPanelBackdrop || !app) {
+      return;
+    }
+
+    const mobileQuery = window.matchMedia('(max-width: 960px)');
+
+    const closePanel = () => {
+      app.classList.remove('player-panel-open');
+      document.body.classList.remove('no-scroll');
+      playerPanelBackdrop.setAttribute('aria-hidden', 'true');
+      playerPanelToggle.setAttribute('aria-expanded', 'false');
+      if (mobileQuery.matches) {
+        playerPanel.setAttribute('aria-hidden', 'true');
+      } else {
+        playerPanel.removeAttribute('aria-hidden');
+      }
+    };
+
+    const openPanel = () => {
+      if (!mobileQuery.matches) return;
+      app.classList.add('player-panel-open');
+      document.body.classList.add('no-scroll');
+      playerPanelBackdrop.setAttribute('aria-hidden', 'false');
+      playerPanelToggle.setAttribute('aria-expanded', 'true');
+      playerPanel.removeAttribute('aria-hidden');
+      requestAnimationFrame(() => playerPanel.focus({ preventScroll: true }));
+    };
+
+    const togglePanel = () => {
+      if (app.classList.contains('player-panel-open')) {
+        closePanel();
+      } else {
+        openPanel();
+      }
+    };
+
+    playerPanelToggle.addEventListener('click', () => {
+      if (mobileQuery.matches) {
+        togglePanel();
+      }
+    });
+
+    if (playerPanelClose) {
+      playerPanelClose.addEventListener('click', closePanel);
+    }
+
+    playerPanelBackdrop.addEventListener('click', closePanel);
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && app.classList.contains('player-panel-open')) {
+        closePanel();
+      }
+    });
+
+    const handleViewportChange = (event) => {
+      if (event.matches) {
+        closePanel();
+      } else {
+        app.classList.remove('player-panel-open');
+        document.body.classList.remove('no-scroll');
+        playerPanelBackdrop.setAttribute('aria-hidden', 'true');
+        playerPanel.removeAttribute('aria-hidden');
+        playerPanelToggle.setAttribute('aria-expanded', 'true');
+      }
+    };
+
+    if (typeof mobileQuery.addEventListener === 'function') {
+      mobileQuery.addEventListener('change', handleViewportChange);
+    } else if (typeof mobileQuery.addListener === 'function') {
+      mobileQuery.addListener(handleViewportChange);
+    }
+    handleViewportChange(mobileQuery);
   }
 
   function updateNavigationLocks() {

--- a/game/index.html
+++ b/game/index.html
@@ -9,7 +9,10 @@
 <body>
   <div id="loading" class="loading">Loading world data...</div>
   <div id="app" class="app hidden" aria-live="polite">
-    <aside class="player-panel" aria-label="Player information">
+    <aside id="playerPanel" class="player-panel" aria-label="Player information" tabindex="-1">
+      <button id="playerPanelClose" class="player-panel-close" type="button" aria-label="Close player panel">
+        ×
+      </button>
       <header class="player-header">
         <h1>Ember Sigil</h1>
         <p class="tagline">A data-driven browser RPG prototype</p>
@@ -72,8 +75,13 @@
         <ul id="playerEquipment"></ul>
       </section>
     </aside>
+    <div id="playerPanelBackdrop" class="player-panel-backdrop" aria-hidden="true" role="presentation"></div>
     <main class="main-area">
       <nav class="activity-tabs" id="activityTabs" aria-label="Gameplay activities">
+        <button id="playerPanelToggle" class="player-panel-toggle" type="button" aria-controls="playerPanel" aria-expanded="false" aria-label="Toggle player panel">
+          <span class="icon" aria-hidden="true">☰</span>
+          <span class="label">Player Menu</span>
+        </button>
         <button data-screen="travel" type="button">Travel</button>
         <button class="active" data-screen="exploration" type="button">Exploration</button>
         <button data-screen="dungeons" type="button">Dungeons</button>


### PR DESCRIPTION
## Summary
- add an off-canvas player panel, overlay backdrop, and mobile toggle controls to the UI
- extend the stylesheet with responsive breakpoints so navigation, panels, and cards adapt on small screens
- wire up mobile-specific behaviour in JavaScript to lock scrolling and handle panel open/close as the viewport changes

## Testing
- not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68cae54b3ee4832095525e26f57d8dd4