### PR TITLE
Enable gear equipping with detailed item previews

### DIFF
--- a/game/data/items.json
+++ b/game/data/items.json
@@ -6,6 +6,7 @@
     "rarity": "common",
     "description": "An old blade with enough bite to get a recruit started.",
     "stats": { "attack": 4 },
+    "classes": ["warden", "templar"],
     "value": 3,
     "tags": ["starter"]
   },
@@ -16,6 +17,7 @@
     "rarity": "common",
     "description": "A dented shield that still knows how to deflect a blow.",
     "stats": { "armor": 6 },
+    "classes": ["warden", "templar"],
     "value": 4,
     "tags": ["starter"]
   },
@@ -26,6 +28,7 @@
     "rarity": "common",
     "description": "A light bow favored by rangers on patrol.",
     "stats": { "attack": 5 },
+    "classes": ["ranger"],
     "value": 5,
     "tags": ["starter"]
   },
@@ -36,6 +39,7 @@
     "rarity": "common",
     "description": "Balanced blades for those who prefer shadows to sunlight.",
     "stats": { "attack": 5 },
+    "classes": ["ranger"],
     "value": 5,
     "tags": ["starter"]
   },
@@ -46,6 +50,7 @@
     "rarity": "common",
     "description": "A worn tome filled with luminous prayers.",
     "stats": { "spellPower": 5 },
+    "classes": ["arcanist", "templar"],
     "value": 6,
     "tags": ["starter"]
   },
@@ -56,6 +61,7 @@
     "rarity": "common",
     "description": "A crystal that amplifies arcane focus when held.",
     "stats": { "spellPower": 3 },
+    "classes": ["arcanist", "templar"],
     "value": 4
   },
   {
@@ -65,6 +71,7 @@
     "rarity": "common",
     "description": "Toughened hide that offers nimble protection.",
     "stats": { "armor": 5 },
+    "classes": ["warden", "ranger"],
     "value": 4
   },
   {
@@ -74,6 +81,7 @@
     "rarity": "common",
     "description": "Threadbare robes woven with faint enchantments.",
     "stats": { "armor": 3, "mana": 10 },
+    "classes": ["arcanist", "templar"],
     "value": 4
   },
   {
@@ -173,6 +181,7 @@
     "rarity": "uncommon",
     "description": "A newly forged blade balanced for seasoned fighters.",
     "stats": { "attack": 9 },
+    "classes": ["warden", "templar"],
     "value": 12
   },
   {
@@ -182,6 +191,7 @@
     "rarity": "uncommon",
     "description": "Wood wrapped in emberweave that channels raw flame.",
     "stats": { "spellPower": 10 },
+    "classes": ["arcanist"],
     "value": 14
   },
   {
@@ -191,6 +201,7 @@
     "rarity": "uncommon",
     "description": "Daggers quenched in the void, eager for backstabs.",
     "stats": { "attack": 10 },
+    "classes": ["ranger"],
     "value": 15
   },
   {
@@ -209,6 +220,7 @@
     "rarity": "rare",
     "description": "A badge of honor granted for defending Emberglade Watch.",
     "stats": { "armor": 4, "attack": 4 },
+    "classes": ["warden", "templar"],
     "value": 25
   }
 ]

--- a/game/game.css
+++ b/game/game.css
@@ -376,11 +376,22 @@ textarea:focus {
 .card-header {
   font-weight: 600;
   margin: 0 0 0.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.5rem;
 }
 
 .card-body {
   color: var(--muted);
   margin: 0 0 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.card-body p {
+  margin: 0;
 }
 
 .card-footer {
@@ -388,6 +399,78 @@ textarea:focus {
   justify-content: space-between;
   align-items: center;
   gap: 0.75rem;
+}
+
+.card.equipped {
+  border-color: rgba(255, 184, 108, 0.55);
+  box-shadow: 0 0 0 1px rgba(255, 184, 108, 0.35), 0 18px 28px rgba(8, 12, 20, 0.4);
+}
+
+.item-tag {
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--accent);
+  border: 1px solid rgba(255, 184, 108, 0.5);
+  border-radius: 999px;
+  padding: 0.1rem 0.5rem;
+  white-space: nowrap;
+}
+
+.item-meta {
+  display: grid;
+  gap: 0.35rem;
+  margin: 0;
+  font-size: 0.85rem;
+}
+
+.item-meta div {
+  display: grid;
+  grid-template-columns: minmax(0, 110px) 1fr;
+  gap: 0.35rem;
+  color: var(--muted);
+}
+
+.item-meta dt {
+  margin: 0;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.item-meta dd {
+  margin: 0;
+}
+
+.item-stats {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+}
+
+.item-stats li {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.item-diff {
+  margin: 0;
+  font-size: 0.85rem;
+}
+
+.item-diff.positive {
+  color: var(--success);
+}
+
+.item-diff.negative {
+  color: var(--danger);
+}
+
+.item-diff.neutral {
+  color: var(--muted);
 }
 
 .log-entries {

--- a/game/index.html
+++ b/game/index.html
@@ -288,7 +288,7 @@
   <template id="inventoryItemTemplate">
     <article class="card">
       <header class="card-header"></header>
-      <p class="card-body"></p>
+      <div class="card-body"></div>
       <div class="card-footer"></div>
     </article>
   </template>
@@ -296,7 +296,7 @@
   <template id="recipeTemplate">
     <article class="card">
       <header class="card-header"></header>
-      <p class="card-body"></p>
+      <div class="card-body"></div>
       <div class="card-footer"></div>
     </article>
   </template>


### PR DESCRIPTION
## Summary
- allow equipping gear directly from the inventory while respecting class restrictions and saving loadouts
- surface item slot, permitted classes, stat bonuses, and projected stat changes on gear cards
- add class metadata and styling/template tweaks so inventory cards can present richer equipment details

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68cb9a2767f48320982e39aa71702f54