### PR TITLE
Add on-screen feedback for key interaction screens

### DIFF
--- a/game/game.css
+++ b/game/game.css
@@ -508,6 +508,41 @@ textarea:focus {
   color: var(--info);
 }
 
+.screen-feedback {
+  margin-top: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  color: var(--muted);
+  line-height: 1.4;
+  transition: border-color 0.2s ease, color 0.2s ease, background 0.2s ease;
+}
+
+.screen-feedback.active {
+  color: var(--text);
+}
+
+.screen-feedback.success {
+  border-color: rgba(74, 222, 128, 0.5);
+  color: var(--success);
+}
+
+.screen-feedback.warning {
+  border-color: rgba(250, 204, 21, 0.45);
+  color: #facc15;
+}
+
+.screen-feedback.danger {
+  border-color: rgba(248, 113, 113, 0.5);
+  color: var(--danger);
+}
+
+.screen-feedback.info {
+  border-color: rgba(96, 165, 250, 0.4);
+  color: var(--info);
+}
+
 .progress-container {
   display: flex;
   flex-direction: column;

--- a/game/index.html
+++ b/game/index.html
@@ -110,6 +110,9 @@
                 <div id="professionRecipes" class="list-grid"></div>
               </section>
             </div>
+            <div id="professionFeedback" class="screen-feedback" role="status" aria-live="polite">
+              Work your trade to gather resources or craft items.
+            </div>
           </section>
         </section>
 
@@ -138,6 +141,9 @@
                 <button id="cancelTravelButton" type="button">Cancel Journey</button>
               </div>
               <div id="travelStatus" class="travel-status"></div>
+              <div id="travelFeedback" class="screen-feedback" role="status" aria-live="polite">
+                Plan your journeys and respond to what unfolds on the road.
+              </div>
             </section>
             <section class="panel">
               <h3>Route Notes</h3>
@@ -172,6 +178,9 @@
                 <button id="refreshMerchantButton" type="button">Refresh Stock</button>
               </div>
               <div id="merchantInfo" class="details-card"></div>
+              <div id="tradeFeedback" class="screen-feedback" role="status" aria-live="polite">
+                Choose goods to buy or sell with the merchants.
+              </div>
             </section>
             <section class="panel">
               <h3>Shop Inventory</h3>
@@ -200,6 +209,9 @@
             <section class="panel">
               <h3>Resident Details</h3>
               <div id="npcDetails" class="details-card"></div>
+              <div id="townFeedback" class="screen-feedback" role="status" aria-live="polite">
+                Speak with residents to hear rumours or request help.
+              </div>
             </section>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- add dedicated feedback panels to the professions, trade, and town screens so results are visible without the adventure log
- track contextual feedback in state and restyle the UI with color-coded status banners
- update gathering, crafting, trading, and town interactions to populate the new panels with success or warning messages

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68cb9e83987c8320b3372448d6553cc3