### PR TITLE
Add camp supplies, day tracking, and ability rest limits

### DIFF
--- a/game/data/items.json
+++ b/game/data/items.json
@@ -103,6 +103,15 @@
     "value": 6
   },
   {
+    "id": "camp_supplies",
+    "name": "Camp Supplies",
+    "type": "supply",
+    "rarity": "common",
+    "description": "Bedrolls, rations, and tinder needed to establish a proper camp.",
+    "value": 4,
+    "tags": ["camp"]
+  },
+  {
     "id": "ember_leaf",
     "name": "Emberleaf",
     "type": "material",

--- a/game/data/npcs.json
+++ b/game/data/npcs.json
@@ -29,9 +29,10 @@
     "inventory": [
       { "itemId": "healing_potion", "price": 8 },
       { "itemId": "mana_potion", "price": 8 },
-      { "itemId": "bronze_sword", "price": 28 }
+      { "itemId": "bronze_sword", "price": 28 },
+      { "itemId": "camp_supplies", "price": 6 }
     ],
-    "buyTypes": ["material", "loot"],
+    "buyTypes": ["material", "loot", "supply"],
     "services": ["trading", "repairs"]
   },
   {

--- a/game/data/zones.json
+++ b/game/data/zones.json
@@ -7,7 +7,7 @@
     "climate": "Temperate wildfire",
     "enemyIds": ["ember_whelp", "ember_sprite", "emberkin_guard"],
     "npcIds": ["sentinel_lyra", "brock_ironbeard", "sage_elowen"],
-    "gatherables": ["ember_leaf", "bronze_ore"],
+    "gatherables": ["ember_leaf", "bronze_ore", "camp_supplies"],
     "dungeonIds": ["ember_halls"],
     "pointsOfInterest": [
       "The Ember Beacon",
@@ -23,7 +23,7 @@
     "climate": "Arctic",
     "enemyIds": ["frost_troll", "glacial_wisp", "frostwarden"],
     "npcIds": ["stormcaller_ivra", "quartermaster_hagan"],
-    "gatherables": ["spring_water", "glimmer_silk"],
+    "gatherables": ["spring_water", "glimmer_silk", "camp_supplies"],
     "dungeonIds": ["frostspire_depths"],
     "pointsOfInterest": [
       "The Frozen Orrery",
@@ -39,7 +39,7 @@
     "climate": "Perpetual dusk",
     "enemyIds": ["umbral_stalker", "voidcaller", "void_revenant"],
     "npcIds": ["shade_broker", "archivist_mira"],
-    "gatherables": ["luminous_thread", "storm_essence"],
+    "gatherables": ["luminous_thread", "storm_essence", "camp_supplies"],
     "dungeonIds": ["umbral_catacombs"],
     "pointsOfInterest": [
       "The Whispering Cairn",

--- a/game/index.html
+++ b/game/index.html
@@ -50,6 +50,14 @@
             <span class="label">Gold</span>
             <span class="value" id="playerGold">0</span>
           </div>
+          <div class="summary-field">
+            <span class="label">Day</span>
+            <span class="value" id="adventureDay">1</span>
+          </div>
+          <div class="summary-field">
+            <span class="label">Camp Supplies</span>
+            <span class="value" id="campSuppliesValue">0</span>
+          </div>
         </section>
         <nav id="screenNav" class="sidebar-nav" aria-label="Game screens">
           <button class="active" data-screen="character" type="button">Character</button>


### PR DESCRIPTION
## Summary
- introduce a day counter with passive regeneration that advances as time passes
- require new camp supplies items for camping, making them available from merchants and travel finds
- enforce ability use limits that recharge on rest and update combat UI to reflect remaining charges

## Testing
- node --check game/game.js

------
https://chatgpt.com/codex/tasks/task_e_68cba54b52b48320964764b25a918eeb