### PR TITLE
Add town roaming option for combat and gathering

### DIFF
--- a/game/index.html
+++ b/game/index.html
@@ -202,7 +202,7 @@
         <section id="screen-town" class="main-screen" aria-labelledby="townTitle">
           <header class="screen-header">
             <h2 id="townTitle">Town</h2>
-            <p class="screen-subtitle">Meet locals, gather rumours, and seek new quests.</p>
+            <p class="screen-subtitle">Meet locals, gather rumours, and patrol the streets for opportunity.</p>
           </header>
           <div class="screen-grid">
             <section class="panel">
@@ -212,13 +212,14 @@
               <div class="button-row">
                 <button id="talkToNpcButton" type="button">Talk</button>
                 <button id="requestQuestButton" type="button">Request Quest</button>
+                <button id="roamTownButton" type="button">Roam the Streets</button>
               </div>
             </section>
             <section class="panel">
               <h3>Resident Details</h3>
               <div id="npcDetails" class="details-card"></div>
               <div id="townFeedback" class="screen-feedback" role="status" aria-live="polite">
-                Speak with residents to hear rumours or request help.
+                Speak with residents, patrol the streets, or request help.
               </div>
             </section>
           </div>


### PR DESCRIPTION
## Summary
- add a Roam the Streets action to the town screen and refresh the helper text
- implement town roaming logic that can trigger combat encounters or gather local resources
- ensure the new action respects existing feedback handling and disables when no settlement is available

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68cbabc2e940832091b1701c8df15997