### PR TITLE
Add dedicated adventure log screen with overlay notifications

### DIFF
--- a/game/game.css
+++ b/game/game.css
@@ -508,6 +508,52 @@ textarea:focus {
   color: var(--info);
 }
 
+.log-overlay {
+  position: fixed;
+  right: 1.5rem;
+  bottom: 1.5rem;
+  width: min(360px, calc(100% - 3rem));
+  max-height: 60vh;
+  display: none;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem 1.25rem;
+  background: rgba(15, 23, 42, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 18px;
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.5);
+  z-index: 60;
+}
+
+.log-overlay.visible {
+  display: flex;
+}
+
+.log-overlay-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.log-overlay-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.log-overlay .close-button {
+  align-self: center;
+  margin: 0;
+  padding: 0;
+  font-size: 1.35rem;
+  line-height: 1;
+  color: var(--muted);
+}
+
+.log-overlay .log-entries {
+  max-height: 45vh;
+}
+
 .screen-feedback {
   margin-top: 0.75rem;
   padding: 0.75rem 1rem;
@@ -818,11 +864,15 @@ textarea:focus {
     font-size: 1.5rem;
   }
 
-  .quest-grid {
-    grid-template-columns: 1fr;
-  }
-
   .combat-container {
     padding: 1.25rem;
+  }
+
+  .log-overlay {
+    left: 1rem;
+    right: 1rem;
+    bottom: 1rem;
+    width: auto;
+    max-height: 50vh;
   }
 }

--- a/game/index.html
+++ b/game/index.html
@@ -65,6 +65,7 @@
           <button data-screen="trade" type="button">Trade</button>
           <button data-screen="town" type="button">Town</button>
           <button data-screen="quests" type="button">Quest Log</button>
+          <button data-screen="log" type="button">Adventure Log</button>
         </nav>
         <div class="sidebar-actions">
           <button id="inventoryToggle" type="button">Inventory</button>
@@ -228,17 +229,23 @@
         <section id="screen-quests" class="main-screen" aria-labelledby="questsTitle">
           <header class="screen-header">
             <h2 id="questsTitle">Quest Log</h2>
-            <p class="screen-subtitle">Track your missions and review the adventure log.</p>
+            <p class="screen-subtitle">Track your missions and progress.</p>
           </header>
-          <div class="screen-grid quest-grid">
+          <div class="screen-grid">
             <section class="panel">
               <div id="questLogContent"></div>
             </section>
-            <section class="panel">
-              <h3>Adventure Log</h3>
-              <div id="logEntries" class="log-entries"></div>
-            </section>
           </div>
+        </section>
+
+        <section id="screen-log" class="main-screen" aria-labelledby="logTitle">
+          <header class="screen-header">
+            <h2 id="logTitle">Adventure Log</h2>
+            <p class="screen-subtitle">Review the chronicle of your hero's journey.</p>
+          </header>
+          <section class="panel">
+            <div id="logEntries" class="log-entries" role="log" aria-live="polite"></div>
+          </section>
         </section>
       </main>
     </div>
@@ -304,6 +311,14 @@
       </header>
       <div id="inventoryList" class="list-grid"></div>
     </div>
+  </div>
+
+  <div id="logOverlay" class="log-overlay" aria-hidden="true" aria-live="polite">
+    <header class="log-overlay-header">
+      <h2>Adventure Log</h2>
+      <button id="logOverlayClose" class="close-button" type="button" aria-label="Hide adventure log overlay">×</button>
+    </header>
+    <div id="logOverlayEntries" class="log-entries" role="log"></div>
   </div>
 
   <template id="inventoryItemTemplate">


### PR DESCRIPTION
## Summary
- add a dedicated adventure log screen and navigation entry
- surface recent log messages in a dismissible overlay when away from the log screen
- update styling and rendering logic to manage overlay visibility and log content

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cbb0bd4ab48320a658b7e170f81bc9