### PR TITLE
Create dedicated professions screen and surface passives

### DIFF
--- a/game/data/classes.json
+++ b/game/data/classes.json
@@ -108,6 +108,27 @@
           }
         },
         {
+          "id": "warden_phalanx_footing",
+          "name": "Phalanx Footing",
+          "type": "passive",
+          "tier": 1,
+          "order": 4,
+          "cost": 1,
+          "description": "Anchor your stance so the shieldwall never breaks.",
+          "statBonuses": {
+            "strength": 1,
+            "armor": 2
+          },
+          "passive": {
+            "name": "Anchored Guard",
+            "description": "Guarding reduces damage by an additional 5% and your counters strike +1 harder.",
+            "modifiers": {
+              "guardDamageReductionBonus": 0.05,
+              "attackBonusFlat": 1
+            }
+          }
+        },
+        {
           "id": "warden_shieldwall_tactics",
           "name": "Shieldwall Tactics",
           "type": "ability",
@@ -180,6 +201,30 @@
           }
         },
         {
+          "id": "warden_reinforced_riposte",
+          "name": "Reinforced Riposte",
+          "type": "passive",
+          "tier": 2,
+          "order": 4,
+          "cost": 2,
+          "minLevel": 4,
+          "minSpent": 3,
+          "requires": [
+            "warden_phalanx_footing"
+          ],
+          "description": "Turn every block into a punishing retaliation.",
+          "statBonuses": {
+            "strength": 2
+          },
+          "passive": {
+            "name": "Counterstrike Drill",
+            "description": "Your retaliation strikes deal 12% more damage.",
+            "modifiers": {
+              "attackMultiplier": 0.12
+            }
+          }
+        },
+        {
           "id": "warden_phoenix_sentinel",
           "name": "Phoenix Sentinel",
           "type": "passive",
@@ -227,6 +272,32 @@
             "modifiers": {
               "guardDamageReductionBonus": 0.1,
               "attackMultiplier": 0.05
+            }
+          }
+        },
+        {
+          "id": "warden_bastion_commander",
+          "name": "Bastion Commander",
+          "type": "passive",
+          "tier": 3,
+          "order": 3,
+          "cost": 3,
+          "minLevel": 7,
+          "minSpent": 7,
+          "requires": [
+            "warden_reinforced_riposte"
+          ],
+          "description": "Direct the shieldwall with unshakable authority.",
+          "statBonuses": {
+            "health": 16,
+            "armor": 4
+          },
+          "passive": {
+            "name": "Bulwark Captain",
+            "description": "Guarding reduces damage by an additional 5% and your presence restores 3% more health.",
+            "modifiers": {
+              "guardDamageReductionBonus": 0.05,
+              "healthRegenPercent": 0.03
             }
           }
         }
@@ -344,6 +415,27 @@
           }
         },
         {
+          "id": "ranger_field_trapper",
+          "name": "Field Trapper",
+          "type": "passive",
+          "tier": 1,
+          "order": 4,
+          "cost": 1,
+          "description": "Lay snares and distractions to dictate the hunt.",
+          "statBonuses": {
+            "agility": 1,
+            "health": 6
+          },
+          "passive": {
+            "name": "Tethered Prey",
+            "description": "Your attacks deal 4% more damage and abilities cost 5% less mana.",
+            "modifiers": {
+              "attackMultiplier": 0.04,
+              "abilityManaCostReductionPercent": 0.05
+            }
+          }
+        },
+        {
           "id": "ranger_arrow_storm",
           "name": "Arrow Storm",
           "type": "ability",
@@ -416,6 +508,32 @@
           }
         },
         {
+          "id": "ranger_hunters_preparation",
+          "name": "Hunter's Preparation",
+          "type": "passive",
+          "tier": 2,
+          "order": 4,
+          "cost": 2,
+          "minLevel": 4,
+          "minSpent": 3,
+          "requires": [
+            "ranger_field_trapper"
+          ],
+          "description": "Plan each strike so foes never recover.",
+          "statBonuses": {
+            "agility": 2,
+            "intellect": 1
+          },
+          "passive": {
+            "name": "Methodical Hunt",
+            "description": "Your attacks deal 8% more damage and regenerate 3% more mana.",
+            "modifiers": {
+              "attackMultiplier": 0.08,
+              "manaRegenPercent": 0.03
+            }
+          }
+        },
+        {
           "id": "ranger_predators_zenith",
           "name": "Predator's Zenith",
           "type": "passive",
@@ -463,6 +581,32 @@
             "modifiers": {
               "healthRegenPercent": 0.05,
               "manaRegenPercent": 0.05
+            }
+          }
+        },
+        {
+          "id": "ranger_shadow_pounce",
+          "name": "Shadow Pounce",
+          "type": "passive",
+          "tier": 3,
+          "order": 3,
+          "cost": 3,
+          "minLevel": 7,
+          "minSpent": 7,
+          "requires": [
+            "ranger_hunters_preparation"
+          ],
+          "description": "Exploit every opening to strike where foes least expect it.",
+          "statBonuses": {
+            "agility": 3,
+            "speed": 2
+          },
+          "passive": {
+            "name": "Opportune Volley",
+            "description": "Your attacks deal 12% more damage and abilities cost 1 less mana.",
+            "modifiers": {
+              "attackMultiplier": 0.12,
+              "abilityManaCostReductionFlat": 1
             }
           }
         }
@@ -579,6 +723,27 @@
           }
         },
         {
+          "id": "arcanist_storm_scholar",
+          "name": "Storm Scholar",
+          "type": "passive",
+          "tier": 1,
+          "order": 4,
+          "cost": 1,
+          "description": "Commit esoteric storm treatises to memory.",
+          "statBonuses": {
+            "intellect": 2,
+            "mana": 10
+          },
+          "passive": {
+            "name": "Scholar's Focus",
+            "description": "Regenerate 3% more mana and abilities cost 5% less mana.",
+            "modifiers": {
+              "manaRegenPercent": 0.03,
+              "abilityManaCostReductionPercent": 0.05
+            }
+          }
+        },
+        {
           "id": "arcanist_static_torrent",
           "name": "Static Torrent",
           "type": "ability",
@@ -651,6 +816,31 @@
           }
         },
         {
+          "id": "arcanist_resonant_conduit",
+          "name": "Resonant Conduit",
+          "type": "passive",
+          "tier": 2,
+          "order": 4,
+          "cost": 2,
+          "minLevel": 4,
+          "minSpent": 3,
+          "requires": [
+            "arcanist_storm_scholar"
+          ],
+          "description": "Shape every bolt to feed the next surge of power.",
+          "statBonuses": {
+            "intellect": 3
+          },
+          "passive": {
+            "name": "Rolling Storm",
+            "description": "Your spells deal 8% more damage and regenerate 4% more mana.",
+            "modifiers": {
+              "attackMultiplier": 0.08,
+              "manaRegenPercent": 0.04
+            }
+          }
+        },
+        {
           "id": "arcanist_eye_of_the_tempest",
           "name": "Eye of the Tempest",
           "type": "passive",
@@ -698,6 +888,32 @@
             "modifiers": {
               "manaRegenPercent": 0.06,
               "abilityManaCostReductionFlat": 2
+            }
+          }
+        },
+        {
+          "id": "arcanist_storm_symphony",
+          "name": "Storm Symphony",
+          "type": "passive",
+          "tier": 3,
+          "order": 3,
+          "cost": 3,
+          "minLevel": 7,
+          "minSpent": 7,
+          "requires": [
+            "arcanist_resonant_conduit"
+          ],
+          "description": "Conduct the tempest as a single, devastating chorus.",
+          "statBonuses": {
+            "intellect": 4,
+            "mana": 16
+          },
+          "passive": {
+            "name": "Conductor's Rhythm",
+            "description": "Your spells deal 12% more damage and abilities cost 1 less mana.",
+            "modifiers": {
+              "attackMultiplier": 0.12,
+              "abilityManaCostReductionFlat": 1
             }
           }
         }
@@ -813,6 +1029,27 @@
           }
         },
         {
+          "id": "templar_vigilant_watch",
+          "name": "Vigilant Watch",
+          "type": "passive",
+          "tier": 1,
+          "order": 4,
+          "cost": 1,
+          "description": "Stand sentinel so the faithful can breathe easy.",
+          "statBonuses": {
+            "health": 6,
+            "mana": 6
+          },
+          "passive": {
+            "name": "Everbright Ward",
+            "description": "Regenerate 2% more health and mana.",
+            "modifiers": {
+              "healthRegenPercent": 0.02,
+              "manaRegenPercent": 0.02
+            }
+          }
+        },
+        {
           "id": "templar_solar_aegis",
           "name": "Solar Aegis",
           "type": "ability",
@@ -886,6 +1123,32 @@
           }
         },
         {
+          "id": "templar_dawnshield_ritual",
+          "name": "Dawnshield Ritual",
+          "type": "passive",
+          "tier": 2,
+          "order": 4,
+          "cost": 2,
+          "minLevel": 4,
+          "minSpent": 3,
+          "requires": [
+            "templar_vigilant_watch"
+          ],
+          "description": "Etch radiant sigils that harden your guard and soothe allies.",
+          "statBonuses": {
+            "health": 12,
+            "intellect": 1
+          },
+          "passive": {
+            "name": "Sunrise Bulwark",
+            "description": "Guarding reduces damage by an additional 10% and regenerate 3% more health.",
+            "modifiers": {
+              "guardDamageReductionBonus": 0.1,
+              "healthRegenPercent": 0.03
+            }
+          }
+        },
+        {
           "id": "templar_avatar_of_light",
           "name": "Avatar of Light",
           "type": "passive",
@@ -934,6 +1197,33 @@
             "modifiers": {
               "abilityManaCostReductionFlat": 2,
               "attackMultiplier": 0.1
+            }
+          }
+        },
+        {
+          "id": "templar_resplendent_icon",
+          "name": "Resplendent Icon",
+          "type": "passive",
+          "tier": 3,
+          "order": 3,
+          "cost": 3,
+          "minLevel": 7,
+          "minSpent": 7,
+          "requires": [
+            "templar_dawnshield_ritual"
+          ],
+          "description": "Shine as a beacon that rallies the devoted.",
+          "statBonuses": {
+            "health": 16,
+            "mana": 12
+          },
+          "passive": {
+            "name": "Radiant Standard",
+            "description": "Regenerate 4% more health and mana and your attacks deal 6% more damage.",
+            "modifiers": {
+              "healthRegenPercent": 0.04,
+              "manaRegenPercent": 0.04,
+              "attackMultiplier": 0.06
             }
           }
         }

--- a/game/game.css
+++ b/game/game.css
@@ -338,6 +338,16 @@ textarea:focus {
   flex: 1 1 auto;
 }
 
+.ability-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.ability-list li {
+  margin: 0;
+}
+
 .ability-entry {
   width: 100%;
   text-align: left;
@@ -364,10 +374,6 @@ textarea:focus {
   box-shadow: 0 12px 26px rgba(15, 23, 42, 0.48);
 }
 
-#playerAbilities li + li {
-  margin-top: 0.75rem;
-}
-
 .ability-entry__name {
   font-size: 1rem;
   font-weight: 600;
@@ -377,6 +383,11 @@ textarea:focus {
   font-size: 0.85rem;
   color: var(--muted);
   letter-spacing: 0.02em;
+}
+
+.ability-entry__details {
+  font-size: 0.8rem;
+  color: rgba(226, 232, 240, 0.78);
 }
 
 .ability-entry__description {
@@ -392,6 +403,86 @@ textarea:focus {
   color: var(--accent);
   padding: 0.2rem 0.55rem;
   border-radius: 999px;
+}
+
+.passive-group {
+  margin-top: 1.5rem;
+  padding-top: 1.25rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.14);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.passive-group h4 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.passive-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.passive-entry {
+  background: rgba(15, 23, 42, 0.35);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.passive-entry__name {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.passive-entry__meta {
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.85);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.passive-entry__description {
+  font-size: 0.85rem;
+  color: var(--muted);
+}
+
+.class-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.class-list li {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.class-ability__name {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.class-ability__meta {
+  font-size: 0.8rem;
+  color: rgba(148, 163, 184, 0.85);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.class-ability__description {
+  font-size: 0.9rem;
+  color: var(--muted);
+}
+
+.professions-grid {
+  align-items: flex-start;
 }
 
 .talent-panel {

--- a/game/game.js
+++ b/game/game.js
@@ -19,50 +19,14 @@
   const PASSIVE_MANA_REGEN_RATE = 0.06;
 
   const abilityLibrary = {
-    'Shield Slam': {
+    'Arcane Surge': {
       usesPerRest: 3,
-      manaCost: 15,
-      damageMultiplier: 1.1,
-      bonusDamage: 8,
-      defenseMitigation: 0.2,
-      minimumDamage: 8,
-      description: 'A crushing blow that staggers foes with your shield.'
-    },
-    'Twin Arrows': {
-      usesPerRest: 3,
-      manaCost: 14,
-      damageMultiplier: 1.05,
-      bonusDamage: 10,
-      defenseMitigation: 0.18,
-      minimumDamage: 8,
-      description: 'Loose two swift arrows that strike vital points.'
-    },
-    'Lightning Coil': {
-      usesPerRest: 3,
-      manaCost: 18,
-      damageMultiplier: 1.2,
-      bonusDamage: 10,
-      defenseMitigation: 0.12,
-      minimumDamage: 10,
-      description: 'Unleash a spiral of chained lightning.'
-    },
-    'Sunlance': {
-      usesPerRest: 3,
-      manaCost: 16,
-      damageMultiplier: 1.15,
-      bonusDamage: 9,
+      manaCost: 22,
+      damageMultiplier: 1.3,
+      bonusDamage: 12,
       defenseMitigation: 0.15,
-      minimumDamage: 9,
-      description: 'Call down a spear of radiant flame.'
-    },
-    Shieldwall: {
-      usesPerRest: 2,
-      manaCost: 18,
-      damageMultiplier: 0.85,
-      bonusDamage: 6,
-      defenseMitigation: 0.55,
-      minimumDamage: 6,
-      description: 'Brace behind your shield to absorb most of the enemy\'s counterattack.'
+      minimumDamage: 11,
+      description: 'Overcharge your spellwork, striking with +12 bonus lightning damage while cutting through 15% of enemy defenses.'
     },
     'Arrow Storm': {
       usesPerRest: 3,
@@ -71,16 +35,88 @@
       bonusDamage: 6,
       defenseMitigation: 0.1,
       minimumDamage: 10,
-      description: 'Unleash a storm of arrows that overwhelms your foe.'
+      description: 'Blanket an area in arrows, adding +6 bonus damage and overwhelming foes even through 10% of their armor.'
     },
-    'Static Torrent': {
+    'Bestial Bond': {
       usesPerRest: 2,
-      manaCost: 24,
-      damageMultiplier: 1.4,
-      bonusDamage: 12,
-      defenseMitigation: 0.05,
-      minimumDamage: 14,
-      description: 'Channel a torrent of crackling energy that devastates your enemy.'
+      manaCost: 16,
+      damageMultiplier: 1.15,
+      bonusDamage: 11,
+      defenseMitigation: 0.18,
+      minimumDamage: 9,
+      description: 'Fight alongside your companion for +11 bonus damage while your combined assault ignores 18% of the target\'s defenses.'
+    },
+    'Bulwark': {
+      usesPerRest: 2,
+      manaCost: 14,
+      damageMultiplier: 0.95,
+      bonusDamage: 9,
+      defenseMitigation: 0.25,
+      minimumDamage: 8,
+      description: 'Set your shield and counter with +9 bonus damage, shrugging off 25% of incoming defense as you hold the line.'
+    },
+    'Camouflaged Step': {
+      usesPerRest: 3,
+      manaCost: 12,
+      damageMultiplier: 1.05,
+      bonusDamage: 7,
+      defenseMitigation: 0.22,
+      minimumDamage: 7,
+      description: 'Slip from cover to deliver +7 bonus damage, striking from the shadows while bypassing 22% of a foe\'s guard.'
+    },
+    "Guardian's Roar": {
+      usesPerRest: 2,
+      manaCost: 12,
+      damageMultiplier: 1,
+      bonusDamage: 7,
+      defenseMitigation: 0.12,
+      minimumDamage: 7,
+      description: 'Unleash a rallying shout that deals steady damage (+7) and rattles foes enough to pierce 12% of their armor.'
+    },
+    'Lightning Coil': {
+      usesPerRest: 3,
+      manaCost: 18,
+      damageMultiplier: 1.2,
+      bonusDamage: 10,
+      defenseMitigation: 0.12,
+      minimumDamage: 10,
+      description: 'Channel chained lightning for +10 bonus damage, ignoring 12% of the target\'s protection as the bolts arc.'
+    },
+    'Radiant Ward': {
+      usesPerRest: 2,
+      manaCost: 15,
+      damageMultiplier: 0.95,
+      bonusDamage: 8,
+      defenseMitigation: 0.28,
+      minimumDamage: 8,
+      description: 'Erect a flare of light that deals +8 bonus damage while repelling 28% of an enemy\'s armor with consecrated force.'
+    },
+    'Revitalizing Hymn': {
+      usesPerRest: 2,
+      manaCost: 18,
+      damageMultiplier: 1.05,
+      bonusDamage: 9,
+      defenseMitigation: 0.2,
+      minimumDamage: 9,
+      description: 'Sing a battle hymn for +9 bonus radiant damage, cutting through 20% of enemy defenses as faith steels your allies.'
+    },
+    'Shield Slam': {
+      usesPerRest: 3,
+      manaCost: 15,
+      damageMultiplier: 1.1,
+      bonusDamage: 8,
+      defenseMitigation: 0.2,
+      minimumDamage: 8,
+      description: 'Drive your shield into the foe, adding +8 bonus damage and battering 20% of their defenses aside.'
+    },
+    'Shieldwall': {
+      usesPerRest: 2,
+      manaCost: 18,
+      damageMultiplier: 0.85,
+      bonusDamage: 6,
+      defenseMitigation: 0.55,
+      minimumDamage: 6,
+      description: 'Lock shields with an explosive bash that still lands +6 bonus damage while shrugging off 55% of retaliation.'
     },
     'Solar Aegis': {
       usesPerRest: 2,
@@ -89,7 +125,43 @@
       bonusDamage: 8,
       defenseMitigation: 0.28,
       minimumDamage: 9,
-      description: 'Surround yourself with radiant light, striking while hardening your defenses.'
+      description: 'Wreathe yourself in solar flame, striking for +8 bonus damage and burning through 28% of enemy armor.'
+    },
+    'Static Torrent': {
+      usesPerRest: 2,
+      manaCost: 24,
+      damageMultiplier: 1.4,
+      bonusDamage: 12,
+      defenseMitigation: 0.05,
+      minimumDamage: 14,
+      description: 'Let loose a roaring torrent of lightning for +12 bonus damage, overwhelming foes even through heavy guard.'
+    },
+    'Sunlance': {
+      usesPerRest: 3,
+      manaCost: 16,
+      damageMultiplier: 1.15,
+      bonusDamage: 9,
+      defenseMitigation: 0.15,
+      minimumDamage: 9,
+      description: 'Call down a spear of solar fire, lancing for +9 bonus damage and piercing 15% of protective wards.'
+    },
+    'Tempest Barrier': {
+      usesPerRest: 2,
+      manaCost: 16,
+      damageMultiplier: 0.9,
+      bonusDamage: 6,
+      defenseMitigation: 0.35,
+      minimumDamage: 8,
+      description: 'Summon a whirling barrier that slams for +6 bonus damage while shunting 35% of enemy defense aside.'
+    },
+    'Twin Arrows': {
+      usesPerRest: 3,
+      manaCost: 14,
+      damageMultiplier: 1.05,
+      bonusDamage: 10,
+      defenseMitigation: 0.18,
+      minimumDamage: 8,
+      description: 'Loose a pair of arrows for +10 bonus damage, threading past 18% of the target\'s armor.'
     }
   };
 
@@ -140,6 +212,7 @@
     manaValue: document.getElementById('manaValue'),
     playerStats: document.getElementById('playerStats'),
     playerAbilities: document.getElementById('playerAbilities'),
+    playerPassives: document.getElementById('playerPassives'),
     talentTree: document.getElementById('talentTree'),
     talentTreeName: document.getElementById('talentTreeName'),
     talentPoints: document.getElementById('talentPoints'),
@@ -239,6 +312,7 @@
 
   const screenRenderers = {
     character: renderCharacterScreen,
+    professions: renderProfessionScreen,
     travel: renderTravelScreen,
     trade: renderTradeScreen,
     town: renderTownScreen,
@@ -392,7 +466,23 @@
       )
       .join('');
     const abilitiesList = (classData.abilities || [])
-      .map((ability) => `<li>${ability}</li>`)
+      .map((ability) => {
+        const definition = getAbilityDefinition(ability);
+        const detailSummary = getAbilityDetailSummary(definition);
+        const detailLine = detailSummary
+          ? `<span class=\"class-ability__meta\">${detailSummary}</span>`
+          : '';
+        const description = definition?.description
+          ? `<span class=\"class-ability__description\">${definition.description}</span>`
+          : '';
+        return `
+          <li>
+            <span class=\"class-ability__name\">${ability}</span>
+            ${detailLine}
+            ${description}
+          </li>
+        `;
+      })
       .join('');
     const kitList = startingItems.length
       ? startingItems.map((item) => `<li>${item}</li>`).join('')
@@ -734,6 +824,7 @@
     syncResourceCaps(state.player);
     updatePlayerPanel();
     renderCharacterScreen();
+    renderProfessionScreen();
     renderTravelScreen();
     renderTradeScreen();
     renderTownScreen();
@@ -775,6 +866,7 @@
     updateResourceBar(elements.manaBar, elements.manaValue, player.resources.mana, maxMana);
     renderPlayerStats();
     renderPlayerAbilities();
+    renderPlayerPassives();
     renderPlayerProfessions();
     renderPlayerEquipment();
   }
@@ -795,10 +887,28 @@
         const base = Math.round(player.stats[stat] || 0);
         const total = Math.round(getTotalStat(player, stat));
         const diff = total - base;
-        const bonus = diff !== 0 ? ` (<span class=\"bonus\">${diff > 0 ? '+' : ''}${diff}</span>)` : '';
+        const bonus = diff !== 0 ? ` (<span class="bonus">${diff > 0 ? '+' : ''}${diff}</span>)` : '';
         return `<li>${toTitle(stat)}: ${total}${bonus}</li>`;
       })
       .join('');
+  }
+
+  function getAbilityDetailSummary(definition) {
+    if (!definition) return '';
+    const parts = [];
+    if (Number.isFinite(definition.damageMultiplier)) {
+      parts.push(`${Math.round(definition.damageMultiplier * 100)}% weapon power`);
+    }
+    if (Number.isFinite(definition.bonusDamage) && definition.bonusDamage !== 0) {
+      parts.push(`+${Math.round(definition.bonusDamage)} bonus damage`);
+    }
+    if (Number.isFinite(definition.defenseMitigation) && definition.defenseMitigation > 0) {
+      parts.push(`Ignores ${Math.round(definition.defenseMitigation * 100)}% defense`);
+    }
+    if (Number.isFinite(definition.minimumDamage) && definition.minimumDamage > 0) {
+      parts.push(`Minimum ${Math.round(definition.minimumDamage)} damage`);
+    }
+    return parts.join(' • ');
   }
 
   function renderPlayerAbilities() {
@@ -825,6 +935,10 @@
           : 'At-will';
         const manaCost = getAbilityManaCostForPlayer(player, definition);
         const manaLabel = Number.isFinite(manaCost) ? `${manaCost} mana` : 'mana cost varies';
+        const detailSummary = getAbilityDetailSummary(definition);
+        const detailLine = detailSummary
+          ? `<span class="ability-entry__details">${detailSummary}</span>`
+          : '';
         const description = definition?.description
           ? `<span class="ability-entry__description">${definition.description}</span>`
           : '';
@@ -837,6 +951,7 @@
             <button type="button" class="ability-entry${activeClass}" data-ability-name="${abilityName}">
               <span class="ability-entry__name">${abilityName}</span>
               <span class="ability-entry__meta">${usesLabel} • ${manaLabel}</span>
+              ${detailLine}
               ${description}
               ${statusBadge}
             </button>
@@ -845,6 +960,42 @@
       })
       .join('');
     elements.playerAbilities.innerHTML = items;
+  }
+
+  function renderPlayerPassives() {
+    if (!elements.playerPassives) return;
+    const player = state.player;
+    if (!player) {
+      elements.playerPassives.innerHTML = '<li class="empty">Unlock talents to gain passive effects.</li>';
+      return;
+    }
+    const passives = getPlayerTalentNodes(player)
+      .filter((node) => node?.passive?.name)
+      .sort((a, b) => {
+        const tierDiff = (a?.tier ?? 99) - (b?.tier ?? 99);
+        if (tierDiff !== 0) return tierDiff;
+        const orderDiff = (a?.order ?? 0) - (b?.order ?? 0);
+        if (orderDiff !== 0) return orderDiff;
+        return (a?.name || '').localeCompare(b?.name || '');
+      });
+    if (!passives.length) {
+      elements.playerPassives.innerHTML = '<li class="empty">Unlock talents to gain passive effects.</li>';
+      return;
+    }
+    elements.playerPassives.innerHTML = passives
+      .map((node) => {
+        const tierLabel = Number.isFinite(node?.tier) ? `Tier ${node.tier}` : 'Talent';
+        const meta = `${tierLabel} • ${node?.name || 'Unknown Source'}`;
+        const description = node.passive.description || 'No description provided yet.';
+        return `
+          <li class="passive-entry">
+            <span class="passive-entry__meta">${meta}</span>
+            <span class="passive-entry__name">${node.passive.name}</span>
+            <span class="passive-entry__description">${description}</span>
+          </li>
+        `;
+      })
+      .join('');
   }
 
   function renderTalentPanel() {
@@ -1066,7 +1217,12 @@
   }
 
   function renderPlayerProfessions() {
-    const professions = state.player.professions || [];
+    const player = state.player;
+    if (!player) {
+      elements.playerProfessions.innerHTML = '<li>No professions trained.</li>';
+      return;
+    }
+    const professions = player.professions || [];
     elements.playerProfessions.innerHTML = professions
       .map((id) => {
         const profession = getProfession(id);
@@ -1095,6 +1251,10 @@
 
   function renderCharacterScreen() {
     renderTalentPanel();
+  }
+
+  function renderProfessionScreen() {
+    renderPlayerProfessions();
     renderProfessionPanel();
   }
 
@@ -1737,10 +1897,12 @@
     if (!player) return 1;
     const totalSpeed = getTotalStat(player, 'speed');
     if (totalSpeed > 0) {
-      return totalSpeed;
+      const scaled = Math.round(totalSpeed * (1.15 + totalSpeed * 0.04));
+      return Math.max(totalSpeed, scaled);
     }
     const agility = getTotalStat(player, 'agility');
-    return Math.max(5, Math.round(agility * 1.2 + 10));
+    const fallback = Math.max(5, Math.round(agility * 1.2 + 10));
+    return Math.max(agility, fallback);
   }
 
   function getEnemySpeed(enemy) {

--- a/game/index.html
+++ b/game/index.html
@@ -61,6 +61,7 @@
         </section>
         <nav id="screenNav" class="sidebar-nav" aria-label="Game screens">
           <button class="active" data-screen="character" type="button">Character</button>
+          <button data-screen="professions" type="button">Professions</button>
           <button data-screen="travel" type="button">Travel</button>
           <button data-screen="trade" type="button">Trade</button>
           <button data-screen="town" type="button">Town</button>
@@ -85,7 +86,11 @@
             </section>
             <section class="panel">
               <h3>Abilities</h3>
-              <ul id="playerAbilities"></ul>
+              <ul id="playerAbilities" class="ability-list"></ul>
+              <div class="passive-group">
+                <h4>Passive Effects</h4>
+                <ul id="playerPassives" class="passive-list"></ul>
+              </div>
             </section>
             <section class="panel">
               <h3>Equipment</h3>
@@ -112,37 +117,52 @@
               Spend talent points to unlock new strengths for your hero.
             </div>
           </section>
-          <section class="panel professions-panel">
-            <header class="panel-header">
-              <h3>Professions</h3>
-              <p class="panel-subtitle">Manage trained disciplines and crafting recipes.</p>
-            </header>
-            <ul id="playerProfessions" class="tag-list"></ul>
-            <div class="form-grid">
-              <label for="professionSelect">Active Profession</label>
-              <select id="professionSelect"></select>
-              <p id="professionDescription" class="description"></p>
-              <label for="recipeSelect">Recipes</label>
-              <select id="recipeSelect"></select>
-            </div>
-            <div class="button-row">
-              <button id="gatherButton" type="button">Gather Resources</button>
-              <button id="craftButton" type="button">Craft Item</button>
-            </div>
-            <div class="profession-details">
-              <section>
-                <h4>Available Gatherables</h4>
-                <ul id="professionGatherables" class="bullet-list"></ul>
-              </section>
-              <section>
-                <h4>Crafting Recipes</h4>
-                <div id="professionRecipes" class="list-grid"></div>
-              </section>
-            </div>
-            <div id="professionFeedback" class="screen-feedback" role="status" aria-live="polite">
-              Work your trade to gather resources or craft items.
-            </div>
-          </section>
+        </section>
+
+        <section id="screen-professions" class="main-screen" aria-labelledby="professionsTitle">
+          <header class="screen-header">
+            <h2 id="professionsTitle">Professions</h2>
+            <p class="screen-subtitle">Manage trained disciplines, gather resources, and craft equipment.</p>
+          </header>
+          <div class="screen-grid professions-grid">
+            <section class="panel">
+              <header class="panel-header">
+                <h3>Active Discipline</h3>
+                <p class="panel-subtitle">Select which trade to focus on while travelling or resting.</p>
+              </header>
+              <ul id="playerProfessions" class="tag-list"></ul>
+              <div class="form-grid">
+                <label for="professionSelect">Trained Profession</label>
+                <select id="professionSelect"></select>
+                <p id="professionDescription" class="description"></p>
+                <label for="recipeSelect">Learned Recipes</label>
+                <select id="recipeSelect"></select>
+              </div>
+              <div class="button-row">
+                <button id="gatherButton" type="button">Gather Resources</button>
+                <button id="craftButton" type="button">Craft Item</button>
+              </div>
+              <div id="professionFeedback" class="screen-feedback" role="status" aria-live="polite">
+                Work your trade to gather resources or craft items.
+              </div>
+            </section>
+            <section class="panel">
+              <header class="panel-header">
+                <h3>Materials &amp; Recipes</h3>
+                <p class="panel-subtitle">Review where to harvest materials and what you can create.</p>
+              </header>
+              <div class="profession-details">
+                <section>
+                  <h4>Available Gatherables</h4>
+                  <ul id="professionGatherables" class="bullet-list"></ul>
+                </section>
+                <section>
+                  <h4>Crafting Recipes</h4>
+                  <div id="professionRecipes" class="list-grid"></div>
+                </section>
+              </div>
+            </section>
+          </div>
         </section>
 
         <section id="screen-travel" class="main-screen" aria-labelledby="travelTitle">


### PR DESCRIPTION
## Summary
- move profession management to a dedicated Professions screen with refreshed layout and navigation
- show unlocked talent passives alongside abilities and expand ability descriptions with mechanical detail
- scale derived speed so higher stat values grant increasingly impactful initiative gains

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cbb69e48e08320bbf9486052dac6c7