### PR TITLE
Adjust adventure log popups

### DIFF
--- a/game/game.css
+++ b/game/game.css
@@ -790,48 +790,63 @@ textarea:focus {
 
 .log-overlay {
   position: fixed;
-  right: 1.5rem;
-  bottom: 1.5rem;
-  width: min(360px, calc(100% - 3rem));
-  max-height: 60vh;
+  top: 1.5rem;
+  left: 50%;
+  transform: translateX(-50%);
+  width: min(420px, calc(100% - 3rem));
   display: none;
   flex-direction: column;
   gap: 0.75rem;
-  padding: 1rem 1.25rem;
-  background: rgba(15, 23, 42, 0.92);
-  border: 1px solid rgba(148, 163, 184, 0.35);
-  border-radius: 18px;
-  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.5);
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: 0;
+  box-shadow: none;
   z-index: 60;
+  pointer-events: none;
 }
 
 .log-overlay.visible {
   display: flex;
+  align-items: stretch;
 }
 
 .log-overlay-header {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-}
-
-.log-overlay-header h2 {
-  margin: 0;
-  font-size: 1.1rem;
+  display: none;
 }
 
 .log-overlay .close-button {
-  align-self: center;
-  margin: 0;
-  padding: 0;
-  font-size: 1.35rem;
-  line-height: 1;
-  color: var(--muted);
+  display: none;
 }
 
 .log-overlay .log-entries {
-  max-height: 45vh;
+  max-height: none;
+  overflow: visible;
+  gap: 0.75rem;
+}
+
+.log-overlay .log-entry {
+  background: rgba(15, 23, 42, 0.92);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: 0 18px 38px rgba(8, 12, 20, 0.45);
+  pointer-events: none;
+}
+
+.log-overlay .log-entry.log-popup-entry {
+  opacity: 0;
+  transform: translateY(-14px);
+  transition: opacity 0.35s ease, transform 0.35s ease;
+}
+
+.log-overlay .log-entry.log-popup-entry.log-popup-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.log-overlay .log-entry.log-popup-entry.log-popup-fading {
+  opacity: 0;
+  transform: translateY(-14px);
+  transition-duration: 2.4s, 1s;
 }
 
 .screen-feedback {


### PR DESCRIPTION
## Summary
- reposition the adventure log overlay to the top of the screen and restyle notifications for standalone popups
- add timed popup handling so each log entry animates in and fades out individually while preserving the full log view

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cbc181f68c8320a7a7a448f6ac8c2e