### PR TITLE
Refactor inventory into slot-based layout

### DIFF
--- a/game/game.css
+++ b/game/game.css
@@ -686,6 +686,76 @@ textarea:focus {
   box-shadow: 0 0 0 1px rgba(255, 184, 108, 0.35), 0 18px 28px rgba(8, 12, 20, 0.4);
 }
 
+.card.inventory-slot {
+  display: flex;
+  flex-direction: column;
+  min-height: 220px;
+}
+
+.card.inventory-slot .card-body {
+  flex: 1;
+}
+
+.card.inventory-slot .card-footer {
+  margin-top: auto;
+}
+
+.card.inventory-slot .card-header {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.35rem;
+}
+
+.card.inventory-slot.empty {
+  border-style: dashed;
+  border-color: rgba(148, 163, 184, 0.35);
+  opacity: 0.7;
+}
+
+.card.inventory-slot.empty .card-body {
+  align-items: center;
+  justify-content: center;
+  min-height: 120px;
+}
+
+.card.inventory-slot.empty .card-body p {
+  color: var(--muted);
+  text-align: center;
+}
+
+.card.inventory-slot.empty .card-footer {
+  justify-content: center;
+  color: var(--muted);
+}
+
+.slot-label {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.empty-slot-text {
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.card.inventory-slot .item-name {
+  font-size: 1.05rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.card.inventory-slot .item-tag {
+  align-self: flex-start;
+}
+
+.item-effect {
+  font-style: italic;
+  color: var(--accent);
+}
+
 .item-tag {
   font-size: 0.7rem;
   text-transform: uppercase;


### PR DESCRIPTION
## Summary
- refactor the player inventory to use discrete slots with optional stacking support and convert save data accordingly
- update inventory rendering, item actions, and trade/camping logic to operate on slot data and surface consumable effects
- refresh inventory styling to display slot numbers, empty placeholders, and effect callouts

## Testing
- Not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cbc7a865a88320a300e7d07c0caa6d