### PR TITLE
Add travel landmarks and finalize destination migration

### DIFF
--- a/game/data/landmarks.json
+++ b/game/data/landmarks.json
@@ -1,0 +1,169 @@
+[
+  {
+    "id": "charred_reliquary",
+    "name": "Charred Reliquary",
+    "category": "dungeon",
+    "description": "Collapsed vaults smolder beneath the pass, their embers watched by ash-marked guardians.",
+    "connectedZoneIds": ["emberglade_watch", "shiverpeak_expanse"],
+    "enemyIds": ["ember_sprite", "emberkin_guard", "ember_spirit"],
+    "gatherables": ["ember_leaf", "ember_coal"],
+    "npcIds": [],
+    "pointsOfInterest": ["Ashen prayer wheels", "Magma-lit reliquaries"],
+    "actions": [
+      {
+        "id": "raid_outer_halls",
+        "type": "reward",
+        "label": "Scavenge the reliquary",
+        "description": "Pick through the collapsed halls for salvageable relics.",
+        "rewards": {
+          "xp": 60,
+          "gold": 18,
+          "items": [
+            { "itemId": "ember_coal", "amount": 1 }
+          ]
+        },
+        "log": "You recover ember-touched relics from the reliquary's fringe chambers.",
+        "logType": "SUCCESS"
+      },
+      {
+        "id": "challenge_guardian",
+        "type": "encounter",
+        "label": "Confront the guardian spirit",
+        "description": "Draw out the reliquary's restless protector.",
+        "enemyId": "ember_spirit",
+        "log": "The reliquary's guardian surges from the smoldering vaults!",
+        "logType": "DANGER"
+      }
+    ]
+  },
+  {
+    "id": "stormfang_aerie",
+    "name": "Stormfang Aerie",
+    "category": "lair",
+    "description": "An icy overhang riddled with nests crackling with trapped stormlight.",
+    "connectedZoneIds": ["shiverpeak_expanse", "umbral_hollow"],
+    "enemyIds": ["frost_troll", "frostwarden"],
+    "gatherables": ["glimmer_silk", "storm_essence"],
+    "npcIds": [],
+    "pointsOfInterest": ["Jagged thunder nests", "Frozen wind tunnels"],
+    "actions": [
+      {
+        "id": "hunt_alpha",
+        "type": "encounter",
+        "label": "Hunt the Stormfang alpha",
+        "description": "Challenge the apex predator guarding the nests.",
+        "enemyId": "frost_troll",
+        "log": "An enraged Stormfang alpha barrels from the ice-crusted ledges!",
+        "logType": "WARNING"
+      },
+      {
+        "id": "harvest_nests",
+        "type": "reward",
+        "label": "Harvest charged nests",
+        "description": "Carefully extract storm-charged silk from the nests.",
+        "rewards": {
+          "xp": 45,
+          "gold": 22,
+          "items": [
+            { "itemId": "glimmer_silk", "amount": 2 }
+          ]
+        },
+        "log": "You gather crackling skeins of glimmer silk from the abandoned nests.",
+        "logType": "SUCCESS"
+      }
+    ]
+  },
+  {
+    "id": "veiled_sanctum",
+    "name": "Veiled Sanctum",
+    "category": "secret",
+    "description": "Hidden glyph-doors part for those who can read the shimmer of twilight.",
+    "connectedZoneIds": ["emberglade_watch", "umbral_hollow"],
+    "enemyIds": ["umbral_stalker"],
+    "gatherables": ["luminous_thread"],
+    "npcIds": [],
+    "pointsOfInterest": ["Shifting sigil mosaics", "Moonlit scriptorium"],
+    "actions": [
+      {
+        "id": "decipher_sigils",
+        "type": "check",
+        "label": "Decipher the shifting sigils",
+        "description": "Attempt to unlock the sanctum's hidden cache.",
+        "successChance": 0.6,
+        "success": {
+          "message": "The sigils flare and reveal a cache of prismatic thread!",
+          "rewards": {
+            "xp": 55,
+            "items": [
+              { "itemId": "luminous_thread", "amount": 2 }
+            ]
+          },
+          "logType": "SUCCESS"
+        },
+        "failure": {
+          "message": "The sigils lash out with a pulse of voidlight, forcing you back.",
+          "logType": "WARNING"
+        }
+      },
+      {
+        "id": "leave_offering",
+        "type": "reward",
+        "label": "Leave a moonlit offering",
+        "description": "Offer provisions to the hidden caretakers in exchange for guidance.",
+        "rewards": {
+          "xp": 25,
+          "gold": 10,
+          "recover": {
+            "healthPercent": 0.2,
+            "manaPercent": 0.2
+          }
+        },
+        "log": "Whispers of gratitude echo as soothing twilight mends your wounds.",
+        "logType": "INFO"
+      }
+    ]
+  },
+  {
+    "id": "twilight_hermitage",
+    "name": "Twilight Hermitage",
+    "category": "npc",
+    "description": "A lone scholar keeps vigil where dusk never fades, trading secrets for stories.",
+    "connectedZoneIds": ["shiverpeak_expanse", "umbral_hollow"],
+    "enemyIds": [],
+    "gatherables": ["camp_supplies"],
+    "npcIds": ["sage_elowen"],
+    "pointsOfInterest": ["Starlit lantern garden", "Chronicles etched into obsidian"],
+    "actions": [
+      {
+        "id": "share_tea",
+        "type": "reward",
+        "label": "Share twilight tea",
+        "description": "Rest with the hermit and recover beneath the starlit lanterns.",
+        "rewards": {
+          "xp": 20,
+          "recover": {
+            "healthPercent": 0.35,
+            "manaPercent": 0.35
+          },
+          "items": [
+            { "itemId": "camp_supplies", "amount": 1 }
+          ]
+        },
+        "log": "The hermit's tea soothes your spirit and replenishes your supplies.",
+        "logType": "INFO"
+      },
+      {
+        "id": "trade_insights",
+        "type": "reward",
+        "label": "Trade insights",
+        "description": "Swap tales with the hermit to glean practical guidance.",
+        "rewards": {
+          "xp": 40,
+          "gold": 28
+        },
+        "log": "You exchange hard-won lessons, leaving with keener insight and a heavier purse.",
+        "logType": "SUCCESS"
+      }
+    ]
+  }
+]

--- a/game/game.css
+++ b/game/game.css
@@ -915,6 +915,54 @@ textarea:focus {
   color: var(--muted);
 }
 
+.landmark-panel {
+  margin-top: 1.5rem;
+  padding: 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.55);
+  box-shadow: 0 14px 28px rgba(15, 23, 42, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.landmark-panel h3 {
+  margin: 0;
+}
+
+.landmark-action {
+  background: rgba(15, 23, 42, 0.45);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 10px;
+  padding: 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  box-shadow: 0 8px 20px rgba(15, 23, 42, 0.3);
+}
+
+.landmark-action button {
+  width: 100%;
+}
+
+.action-description {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+  line-height: 1.5;
+}
+
+.button-column {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.button-column button {
+  width: 100%;
+}
+
 .focus-group {
   display: flex;
   flex-direction: column;

--- a/game/index.html
+++ b/game/index.html
@@ -197,10 +197,19 @@
             <section class="panel">
               <h3>Route Notes</h3>
               <ul id="travelDestinationMeta" class="bullet-list"></ul>
+              <h3>Waypoints En Route</h3>
+              <ul id="travelDestinationLandmarks" class="bullet-list"></ul>
               <h3>Highlights</h3>
               <ul id="travelDestinationHighlights" class="bullet-list"></ul>
               <h3>Threat Assessment</h3>
               <ul id="travelDestinationThreats" class="bullet-list"></ul>
+              <div id="currentLandmarkPanel" class="landmark-panel hidden" aria-live="polite">
+                <h3 id="currentLandmarkTitle">Roadside Landmark</h3>
+                <p id="currentLandmarkDescription" class="description"></p>
+                <ul id="currentLandmarkDetails" class="bullet-list"></ul>
+                <div id="currentLandmarkActions" class="button-column"></div>
+                <div id="currentLandmarkFeedback" class="screen-feedback" role="status"></div>
+              </div>
               <div class="progress-container">
                 <span>Journey Progress</span>
                 <div class="progress-bar">


### PR DESCRIPTION
## Summary
- add a landmark dataset plus UI scaffolding for on-route interactions
- finalize the travel destination migration with landmark-aware journey handling
- normalize save data to the new travel schema and surface landmark feedback styling
- wire up the missing landmark accessor so landmark destinations load and travel can start

## Testing
- python -m json.tool game/data/landmarks.json

------
https://chatgpt.com/codex/tasks/task_e_68cbc2e403748320879633527447f740